### PR TITLE
Skip .settings folders generated by Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ local
 # Eclipse, Netbeans and IntelliJ files
 .project
 .classpath
+.settings
 nbproject
 .idea
 *.ipr


### PR DESCRIPTION
Hi,

Eclipse generates .settings folders with files storing project specific settings. Would be good to filter it using .gitignore.