### PR TITLE
Possible implementation of WLST usage for Weblogic domain creation and modifications

### DIFF
--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
@@ -1,0 +1,141 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2015 Vincent Massol.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.cargo.container.LocalContainer;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
+import org.codehaus.cargo.container.configuration.entry.DataSource;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+import org.codehaus.cargo.container.spi.configuration.AbstractStandaloneLocalConfiguration;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic8xConfigurationBuilder;
+
+/**
+ * Contains common Weblogic configuration functionality for WLST.
+ */
+public abstract class AbstractWebLogicWlstStandaloneLocalConfiguration extends
+    AbstractStandaloneLocalConfiguration implements WebLogicConfiguration
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see AbstractLocalConfiguration#AbstractLocalConfiguration(String)
+     */
+    public AbstractWebLogicWlstStandaloneLocalConfiguration(String dir)
+    {
+        super(dir);
+    }
+
+    /**
+     * @param container Container the dataSource will be configured on.
+     * @return Configuration builder that produces WLST script for DataSource creation.
+     */
+    protected abstract ConfigurationBuilder createConfigurationBuilder(LocalContainer container);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(LocalContainer container)
+    {
+        super.configure(container);
+        configureDataSources(container);
+        configureResources(container);
+    }
+
+    /**
+     * Configure datasources.
+     *
+     * @param container Container the datasource will be configured on.
+     */
+    protected void configureDataSources(LocalContainer container)
+    {
+        WebLogic121xWlstInstalledLocalContainer weblogicContainer =
+            (WebLogic121xWlstInstalledLocalContainer) container;
+        List<String> configurationScript = new ArrayList<String>();
+
+        for (DataSource dataSource : getDataSources())
+        {
+            configurationScript.add("cd('/')");
+            configurationScript.add(configure(dataSource, container));
+        }
+
+        weblogicContainer.modifyDomainConfigurationWithWlst(configurationScript);
+    }
+
+    /**
+     * Returns configuration script for datasource.
+     *
+     * @param ds Datasource to be configured.
+     * @param container Container the dataSource will be configured on.
+     * @return Configuration script.
+     */
+    protected String configure(DataSource ds, LocalContainer container)
+    {
+        ConfigurationBuilder builder = this.createConfigurationBuilder(container);
+        String configurationEntry = builder.toConfigurationEntry(ds);
+        return configurationEntry;
+    }
+
+    /**
+     * Configure resources.
+     *
+     * @param container Container the datasource will be configured on.
+     */
+    protected void configureResources(LocalContainer container)
+    {
+        WebLogic121xWlstInstalledLocalContainer weblogicContainer =
+            (WebLogic121xWlstInstalledLocalContainer) container;
+        List<String> configurationScript = new ArrayList<String>();
+
+        for (Resource resource : getResources())
+        {
+            configurationScript.add("cd('/')");
+            configurationScript.add(configure(resource, container));
+        }
+
+        weblogicContainer.modifyDomainConfigurationWithWlst(configurationScript);
+    }
+
+    /**
+     * Returns configuration script for datasource.
+     *
+     * @param resource Resource to be configured.
+     * @param container Container the dataSource will be configured on.
+     * @return Configuration script.
+     */
+    protected String configure(Resource resource, LocalContainer container)
+    {
+        throw new UnsupportedOperationException(
+            WebLogic8xConfigurationBuilder.RESOURCE_CONFIGURATION_UNSUPPORTED);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDomainHome()
+    {
+        return getHome();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstInstalledLocalContainer.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstInstalledLocalContainer.java
@@ -1,0 +1,242 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2015 Vincent Massol.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.codehaus.cargo.container.ContainerException;
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.property.ServletPropertySet;
+import org.codehaus.cargo.container.property.User;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncher;
+import org.codehaus.cargo.container.weblogic.internal.AbstractWebLogicInstalledLocalContainer;
+import org.codehaus.cargo.util.CargoException;
+
+/**
+ * Special container support for the Bea WebLogic 12.1.3 application server. Contains WLST support.
+ */
+public class WebLogic121xWlstInstalledLocalContainer extends AbstractWebLogicInstalledLocalContainer
+{
+
+    /**
+     * Unique container id.
+     */
+    public static final String ID = "weblogic121x";
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see AbstractWebLogicInstalledLocalContainer#AbstractWebLogicInstalledLocalContainer(org.codehaus.cargo.container.configuration.LocalConfiguration)
+     */
+    public WebLogic121xWlstInstalledLocalContainer(LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codehaus.cargo.container.Container#getName()
+     */
+    public String getName()
+    {
+        return "WebLogic 12.1.x";
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codehaus.cargo.container.Container#getId()
+     */
+    public String getId()
+    {
+        return ID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String getAutoDeployDirectory()
+    {
+        return "autodeploy";
+    }
+
+    /**
+     * {@inheritDoc} Also includes checking of the modules directory, which is unique to WebLogic
+     * 10.
+     *
+     * @see org.codehaus.cargo.container.weblogic.internal.AbstractWebLogicInstalledLocalContainer#getBeaHomeDirs()
+     */
+    @Override
+    protected List<String> getBeaHomeDirs()
+    {
+        List<String> beaHomeDirs = super.getBeaHomeDirs();
+        beaHomeDirs.add(getFileHandler().append(getWeblogicHome(), "modules"));
+        return beaHomeDirs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected List<String> getBeaHomeFiles()
+    {
+        List<String> requiredFiles = new ArrayList<String>();
+        requiredFiles.add(getFileHandler().append(getBeaHome(), "inventory/registry.xml"));
+        return requiredFiles;
+    }
+
+    /**
+     * {@inheritDoc}.
+     */
+    @Override
+    protected void executePostStartTasks() throws Exception
+    {
+        List<String> configurationScript = new ArrayList<String>();
+        configurationScript.add(String.format("connect('%s','%s','t3://localhost:%s')",
+            getConfiguration().getPropertyValue(WebLogicPropertySet.ADMIN_USER),
+            getConfiguration().getPropertyValue(WebLogicPropertySet.ADMIN_PWD),
+            getConfiguration().getPropertyValue(ServletPropertySet.PORT)));
+        configurationScript.add(String.format("cd('/SecurityConfiguration/%s/Realms/"
+            + "myrealm/AuthenticationProviders/DefaultAuthenticator')", getDomainName()));
+
+        Set<String> roles = new HashSet<String>();
+        for (User user : User.parseUsers(getConfiguration().getPropertyValue(
+            ServletPropertySet.USERS)))
+        {
+            configurationScript.add(String.format("cmo.createUser('%s','%s','%s')",
+                user.getName(), user.getPassword(), user.getName()));
+
+            for (String role : user.getRoles())
+            {
+                roles.add(role);
+            }
+        }
+
+        for (String role : roles)
+        {
+            configurationScript.add(String.format("cmo.createGroup('%s','%s')", role, role));
+        }
+
+        for (User user : User.parseUsers(getConfiguration().getPropertyValue(
+            ServletPropertySet.USERS)))
+        {
+            for (String role : user.getRoles())
+            {
+                configurationScript.add(String.format("cmo.addMemberToGroup('%s','%s')", role,
+                    user.getName()));
+            }
+        }
+
+        writeWithWlst(configurationScript);
+    }
+
+    /**
+     * Used for modifying domain configuration with script provided as parameter.
+     *
+     * @param configurationScript Script containing WLST configuration for domain modifications.
+     */
+    public void modifyDomainConfigurationWithWlst(Collection<String> configurationScript)
+    {
+        List<String> completeScript = new ArrayList<String>();
+        completeScript.add(String.format("readDomain('%s')", getDomainHome()));
+        completeScript.add("cd('/')");
+        completeScript.addAll(configurationScript);
+        completeScript.add("updateDomain()");
+        completeScript.add("closeDomain()");
+
+        writeWithWlst(completeScript);
+    }
+
+    /**
+     * Writes configuration script using WLST.
+     *
+     * @param configurationScript Script containing WLST configuration to be executed.
+     */
+    public void writeWithWlst(Collection<String> configurationScript)
+    {
+        configurationScript.add("dumpStack()");
+
+        String newLine = System.getProperty("line.separator");
+        StringBuffer buffer = new StringBuffer();
+        for (String configuration : configurationScript)
+        {
+            buffer.append(configuration);
+            buffer.append(newLine);
+        }
+
+        getLogger().debug("Sending WLST script: " + newLine + buffer.toString(),
+            this.getClass().getName());
+
+        try
+        {
+            // script is stored to *.py file which is added as parameter when invoking WLST
+            // configuration class
+            File filename = File.createTempFile("wlst", ".py");
+            filename.deleteOnExit();
+            PrintWriter scriptWriter = new PrintWriter(filename);
+            scriptWriter.println(buffer.toString());
+            scriptWriter.flush();
+            scriptWriter.close();
+
+            JvmLauncher java = createJvmLauncher(false);
+
+            addWlstArguments(java);
+
+            java.addAppArgument(filename);
+            int result = java.execute();
+            if (result != 0)
+            {
+                throw new ContainerException("Failure when invoking WLST script, java returned "
+                    + result);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new CargoException("Cannot execute WLST script.", e);
+        }
+    }
+
+    /**
+     * Adding WLST dependencies and setting main class.
+     *
+     * @param java Launcher.
+     */
+    private void addWlstArguments(JvmLauncher java)
+    {
+        File serverDir = new File(this.getHome(), "server");
+        java.addClasspathEntries(new File(serverDir, "lib/weblogic.jar"));
+        java.setMainClass("weblogic.WLST");
+    }
+
+    /**
+     * @return Domain name.
+     */
+    protected String getDomainName()
+    {
+        return getFileHandler().getName(getDomainHome());
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfiguration.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfiguration.java
@@ -1,0 +1,163 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2015 Vincent Massol.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.cargo.container.LocalContainer;
+import org.codehaus.cargo.container.configuration.ConfigurationCapability;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
+import org.codehaus.cargo.container.property.GeneralPropertySet;
+import org.codehaus.cargo.container.property.ServletPropertySet;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xDataSourceConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.WebLogicLocalContainer;
+
+/**
+ * WebLogic 12.1.x standalone
+ * {@link org.codehaus.cargo.container.spi.configuration.ContainerConfiguration} implementation.
+ * WebLogic 12.1.x uses WLST for container configuration.
+ */
+public class WebLogic121xWlstStandaloneLocalConfiguration extends
+    AbstractWebLogicWlstStandaloneLocalConfiguration
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see AbstractLocalConfiguration#AbstractLocalConfiguration(String)
+     */
+    public WebLogic121xWlstStandaloneLocalConfiguration(String dir)
+    {
+        super(dir);
+
+        setProperty(WebLogicPropertySet.ADMIN_USER, "weblogic");
+        setProperty(WebLogicPropertySet.ADMIN_PWD, "weblogic1");
+        setProperty(WebLogicPropertySet.SERVER, "server");
+        setProperty(WebLogicPropertySet.CONFIGURATION_VERSION, "12.1.3.0");
+        setProperty(WebLogicPropertySet.DOMAIN_VERSION, "12.1.3.0");
+        setProperty(ServletPropertySet.PORT, "7001");
+        setProperty(GeneralPropertySet.HOSTNAME, "localhost");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ConfigurationCapability getCapability()
+    {
+        return new WebLogic9x10x103x12xStandaloneLocalConfigurationCapability();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected ConfigurationBuilder createConfigurationBuilder(LocalContainer container)
+    {
+        return new WebLogic9x10x103x12xDataSourceConfigurationBuilder(container.getConfiguration());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doConfigure(LocalContainer container) throws Exception
+    {
+        setupConfigurationDir();
+
+        WebLogic121xWlstInstalledLocalContainer weblogicContainer =
+            (WebLogic121xWlstInstalledLocalContainer) container;
+
+        // create domain
+        createNewDomain(weblogicContainer);
+
+        // deploy war
+        WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer deployer =
+            new WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer(weblogicContainer);
+        deployer.deploy(getDeployables());
+
+        // deploy cargo ping
+        deployCargoPing(weblogicContainer);
+    }
+
+    /**
+     * Creates new domain from Weblogic template.
+     *
+     * @param weblogicContainer Weblogic container.
+     */
+    private void createNewDomain(WebLogic121xWlstInstalledLocalContainer weblogicContainer)
+    {
+        String weblogicHome = weblogicContainer.getWeblogicHome();
+
+        // script for loading default Weblogic domain form template, configuring port and
+        // administration user and storing domain
+        List<String> configurationScript = new ArrayList<String>();
+        configurationScript.add(String.format("readTemplate('%s/common/templates/wls/wls.jar')",
+            weblogicHome));
+        configurationScript.add("cd('/')");
+        configurationScript.add("cd('Servers/AdminServer')");
+        configurationScript.add(String.format("cmo.setName('%s')",
+            getPropertyValue(WebLogicPropertySet.SERVER)));
+        configurationScript.add(String.format("set('ListenPort', %s)",
+            getPropertyValue(ServletPropertySet.PORT)));
+        configurationScript.add("cd('/')");
+        configurationScript.add("cd('Security/base_domain/User/weblogic')");
+        configurationScript.add(String.format("cmo.setName('%s')",
+            getPropertyValue(WebLogicPropertySet.ADMIN_USER)));
+        configurationScript.add(String.format("cmo.setPassword('%s')",
+            getPropertyValue(WebLogicPropertySet.ADMIN_PWD)));
+        configurationScript.add("cd('/')");
+        configurationScript.add("setOption('OverwriteDomain', 'true')");
+        configurationScript.add(String.format("writeDomain('%s')", getDomainHome()));
+        configurationScript.add("closeTemplate()");
+
+        weblogicContainer.writeWithWlst(configurationScript);
+    }
+
+    /**
+     * Deploy the Cargo Ping utility to the container.
+     *
+     * @param container the container to configure
+     * @throws IOException if the cargo ping deployment fails
+     */
+    private void deployCargoPing(WebLogicLocalContainer container) throws IOException
+    {
+        // as this is an initial install, this directory will not exist, yet
+        String deployDir =
+            getFileHandler().createDirectory(getDomainHome(), container.getAutoDeployDirectory());
+
+        // Deploy the cargocpc web-app by copying the WAR file
+        getResourceUtils().copyResource(RESOURCE_PATH + "cargocpc.war",
+            getFileHandler().append(deployDir, "cargocpc.war"), getFileHandler());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return "WebLogic 12.1.x Standalone Configuration";
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer.java
@@ -1,0 +1,165 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.cargo.container.InstalledLocalContainer;
+import org.codehaus.cargo.container.deployable.Deployable;
+import org.codehaus.cargo.container.deployable.DeployableException;
+import org.codehaus.cargo.container.deployable.DeployableType;
+import org.codehaus.cargo.container.deployable.EAR;
+import org.codehaus.cargo.container.deployable.WAR;
+import org.codehaus.cargo.container.spi.deployer.AbstractInstalledLocalDeployer;
+
+/**
+ * Static deployer that manages deployment configuration calling WLST offline script.
+ *
+ */
+public class WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer extends
+    AbstractInstalledLocalDeployer
+{
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param container container to configure
+     */
+    public WebLogic9x10x103x12xWlstOfflineInstalledLocalDeployer(InstalledLocalContainer container)
+    {
+        super(container);
+    }
+
+    /**
+     * {@inheritDoc} deploys files by sending WLST script to WebLogic server.
+     *
+     * @see org.codehaus.cargo.container.spi.deployer.AbstractDeployer#deploy(org.codehaus.cargo.container.deployable.Deployable)
+     */
+    @Override
+    public void deploy(Deployable deployable)
+    {
+        WebLogic121xWlstInstalledLocalContainer weblogicContainer =
+            (WebLogic121xWlstInstalledLocalContainer) getContainer();
+
+        String id = createIdForDeployable(deployable);
+        String path = getAbsolutePath(deployable);
+        String serverName = getServerName();
+
+        // script for deploying deployable to Weblogic using WLST
+        List<String> configurationScript = new ArrayList<String>();
+        configurationScript.add(String.format("app=create('%s','AppDeployment')", id));
+        configurationScript.add(String.format("app.setSourcePath('%s')", path));
+        configurationScript.add("cd('/')");
+        configurationScript.add(String.format(
+            "assign('AppDeployment', '%s', 'Target', '%s')",
+            id, serverName));
+
+        weblogicContainer.modifyDomainConfigurationWithWlst(configurationScript);
+    }
+
+    /**
+     * {@inheritDoc} undeploys files by sending WLST script to WebLogic server.
+     *
+     * @see org.codehaus.cargo.container.spi.deployer.AbstractDeployer#undeploy(org.codehaus.cargo.container.deployable.Deployable)
+     */
+    @Override
+    public void undeploy(Deployable deployable)
+    {
+        WebLogic121xWlstInstalledLocalContainer weblogicContainer =
+            (WebLogic121xWlstInstalledLocalContainer) getContainer();
+
+        String id = createIdForDeployable(deployable);
+
+        List<String> configurationScript = new ArrayList<String>();
+        configurationScript.add(String.format("delete('%s','AppDeployment')", id));
+
+        weblogicContainer.modifyDomainConfigurationWithWlst(configurationScript);
+    }
+
+    /**
+     * Get a string name for the configuration of this deployable. This should be XML friendly. For
+     * example, the String returned will have no slashes or colons, and be as short as possible.
+     *
+     * @param deployable used to construct the id
+     * @return a string that can be used to name this configuration
+     */
+    protected String createIdForDeployable(Deployable deployable)
+    {
+        String name = null;
+        // TODO this code should be moved into the deployable objects themselves, as they
+        // are better responsible for their name.
+        if (deployable.getType() == DeployableType.WAR)
+        {
+            name = ((WAR) deployable).getContext();
+        }
+        else if (deployable.getType() == DeployableType.EAR)
+        {
+            name = ((EAR) deployable).getName();
+        }
+        else if (deployable.getType() == DeployableType.EJB
+            || deployable.getType() == DeployableType.RAR)
+        {
+            name = createIdFromFileName(deployable);
+        }
+        else
+        {
+            throw new DeployableException("name extraction for " + deployable.getType()
+                + " not currently supported");
+        }
+        return name;
+    }
+
+    /**
+     * Get a string name for the configuration of this deployable based on its filename.
+     *
+     * @param deployable used to construct the id
+     * @return a string that can be used to name this configuration
+     */
+    protected String createIdFromFileName(Deployable deployable)
+    {
+        File file = new File(deployable.getFile());
+        return file.getName();
+    }
+
+    /**
+     * return the running server's name.
+     *
+     * @return the WebLogic server's name
+     */
+    private String getServerName()
+    {
+        return getContainer().getConfiguration().getPropertyValue(WebLogicPropertySet.SERVER);
+    }
+
+    /**
+     * gets the absolute path from a file that may be relative to the current directory.
+     *
+     * @param deployable - what to extract the file path from
+     * @return - absolute path to the deployable
+     */
+    private String getAbsolutePath(Deployable deployable)
+    {
+        String path = deployable.getFile();
+        return getFileHandler().getAbsolutePath(path);
+    }
+
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogicFactoryRegistry.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogicFactoryRegistry.java
@@ -148,7 +148,7 @@ public class WebLogicFactoryRegistry extends AbstractFactoryRegistry
 
         configurationFactory.registerConfiguration("weblogic121x",
             ContainerType.INSTALLED, ConfigurationType.STANDALONE,
-            WebLogic121xStandaloneLocalConfiguration.class);
+            WebLogic121xWlstStandaloneLocalConfiguration.class);
         configurationFactory.registerConfiguration("weblogic121x",
             ContainerType.INSTALLED, ConfigurationType.EXISTING,
             WebLogic9x10x103x12xExistingLocalConfiguration.class);
@@ -210,7 +210,7 @@ public class WebLogicFactoryRegistry extends AbstractFactoryRegistry
             WebLogic12xInstalledLocalContainer.class);
 
         containerFactory.registerContainer("weblogic121x", ContainerType.INSTALLED,
-            WebLogic121xInstalledLocalContainer.class);
+            WebLogic121xWlstInstalledLocalContainer.class);
     }
 
     /**

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogic9x10x103x12xDataSourceConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogic9x10x103x12xDataSourceConfigurationBuilder.java
@@ -1,0 +1,139 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2015 Vincent Massol.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal;
+
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationEntryType;
+import org.codehaus.cargo.container.configuration.entry.DataSource;
+import org.codehaus.cargo.container.property.TransactionSupport;
+import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
+
+/**
+ * Create WLST script for adding DataSource to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xDataSourceConfigurationBuilder extends
+    WebLogic9x10x103x12xConfigurationBuilder
+{
+    /**
+     * Sets the server name that the resources this creates are bound to.
+     *
+     * @param configuration containing needed server name.
+     */
+    public WebLogic9x10x103x12xDataSourceConfigurationBuilder(LocalConfiguration configuration)
+    {
+        super(configuration.getPropertyValue(WebLogicPropertySet.SERVER));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String configureDataSourceWithImplementationClass(DataSource ds, String className)
+    {
+        String newline = System.getProperty("line.separator");
+
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("create('%s','JDBCSystemResource')", ds.getId()));
+        buffer.append(newline);
+        buffer.append(String.format("cd('JDBCSystemResource/%s/JdbcResource/%s')", ds.getId(),
+            ds.getId()));
+        buffer.append(newline);
+        buffer.append("create('myJdbcDriverParams','JDBCDriverParams')");
+        buffer.append(newline);
+        buffer.append("cd('JDBCDriverParams/NO_NAME_0')");
+        buffer.append(newline);
+        buffer.append(String.format("set('DriverName','%s')", className));
+
+        if (ds.getUrl() != null)
+        {
+            buffer.append(newline);
+            buffer.append(String.format("set('URL','%s')", ds.getUrl()));
+        }
+
+        if (ds.getPassword() != null)
+        {
+            buffer.append(newline);
+            buffer.append(String.format("set('PasswordEncrypted', '%s')", ds.getPassword()));
+        }
+
+        buffer.append(newline);
+        buffer.append("create('myProps','Properties')");
+        buffer.append(newline);
+        buffer.append("cd('Properties/NO_NAME_0')");
+        buffer.append(newline);
+        buffer.append("create('user', 'Property')");
+        buffer.append(newline);
+        buffer.append("cd('Property/user')");
+        buffer.append(newline);
+        buffer.append(String.format("cmo.setValue('%s')", ds.getUsername()));
+
+        Set<Entry<Object, Object>> driverProperties = ds.getConnectionProperties().entrySet();
+        for (Entry<Object, Object> driverProperty : driverProperties)
+        {
+            String name = driverProperty.getKey().toString();
+            String value = driverProperty.getValue().toString();
+            buffer.append(newline);
+            buffer.append("cd('../..')");
+            buffer.append(newline);
+            buffer.append(String.format("create('%s', 'Property')", name));
+            buffer.append(newline);
+            buffer.append(String.format("cd('Property/%s')", name));
+            buffer.append(newline);
+            buffer.append(String.format("cmo.setValue('%s')", value));
+        }
+
+        buffer.append(newline);
+        buffer.append(String.format("cd('/JDBCSystemResource/%s/JdbcResource/%s')", ds.getId(),
+            ds.getId()));
+        buffer.append(newline);
+        buffer.append("create('myJdbcDataSourceParams','JDBCDataSourceParams')");
+        buffer.append(newline);
+        buffer.append("cd('JDBCDataSourceParams/NO_NAME_0')");
+        buffer.append(newline);
+        buffer.append(String.format("set('JNDIName','%s')", ds.getJndiLocation()));
+
+        if (ds.getConnectionType().equals(ConfigurationEntryType.XA_DATASOURCE))
+        {
+            buffer.append(newline);
+            buffer.append("set('GlobalTransactionsProtocol','TwoPhaseCommit')");
+        }
+        else if (ds.getTransactionSupport().equals(TransactionSupport.XA_TRANSACTION))
+        {
+            buffer.append(newline);
+            buffer.append("set('GlobalTransactionsProtocol','EmulateTwoPhaseCommit')");
+        }
+        else
+        {
+            buffer.append(newline);
+            buffer.append("set('GlobalTransactionsProtocol','None')");
+        }
+
+        buffer.append(newline);
+        buffer.append("cd('/')");
+        buffer.append(newline);
+        buffer.append(String.format("assign('JDBCSystemResource', '%s', 'Target', '%s')",
+            ds.getId(), getServerName()));
+
+        return buffer.toString();
+    }
+}


### PR DESCRIPTION
Hi,

This is my idea of how WLST could be implemented for Cargo Weblogic container. It could be useful to get rid of deprecated weblogic.Admin and mixing different XML config files. It could bring better flexibility for extending configuration with various options and resources.

Tests are missing as this is kind of proof of concept and it could be complicated to test WLST - it uses python scripts which are executed by Weblogic own tool.

What do you think about this?