### PR TITLE
Adding Id property for resources to be possible to set resource name

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/configuration/entry/Resource.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/configuration/entry/Resource.java
@@ -45,6 +45,11 @@ public class Resource
     private String className;
 
     /**
+     * id used in configuration files.
+     */
+    private String id;
+
+    /**
      * Resource parameters.
      */
     private Map<String, String> parameters;
@@ -147,4 +152,21 @@ public class Resource
         return className;
     }
 
+    /**
+     * @param id id used in configuration files.
+     */
+    public void setId(String id)
+    {
+        this.id = id;
+    }
+
+    /**
+     * The String used to identify this resource in configuration files.
+     *
+     * @return the resource id
+     */
+    public String getId()
+    {
+        return this.id;
+    }
 }

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/property/ResourcePropertySet.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/property/ResourcePropertySet.java
@@ -51,6 +51,11 @@ public interface ResourcePropertySet
     String RESOURCE_CLASS = "cargo.resource.class";
 
     /**
+     * Unique id to use in configuration files. <br>
+     */
+    String RESOURCE_ID = "cargo.resource.id";
+
+    /**
      * Parameters passed to the implementation class. <br>
      */
     String PARAMETERS = "cargo.resource.parameters";

--- a/core/api/container/src/test/java/org/codehaus/cargo/container/configuration/entry/ResourceFixture.java
+++ b/core/api/container/src/test/java/org/codehaus/cargo/container/configuration/entry/ResourceFixture.java
@@ -47,6 +47,11 @@ public class ResourceFixture
     public String className;
 
     /**
+     * Resource id.
+     */
+    public String id;
+
+    /**
      * Parameters.
      */
     public String parameters;
@@ -76,6 +81,8 @@ public class ResourceFixture
         PropertyUtils.setPropertyIfNotNull(properties, ResourcePropertySet.RESOURCE_TYPE, type);
         PropertyUtils.setPropertyIfNotNull(properties, ResourcePropertySet.RESOURCE_CLASS,
             className);
+        PropertyUtils.setPropertyIfNotNull(properties, ResourcePropertySet.RESOURCE_ID,
+            id);
         PropertyUtils.setPropertyIfNotNull(properties, ResourcePropertySet.RESOURCE_NAME, name);
         PropertyUtils
             .setPropertyIfNotNull(properties, ResourcePropertySet.PARAMETERS, parameters);

--- a/core/api/container/src/test/java/org/codehaus/cargo/container/property/ResourceConverterTest.java
+++ b/core/api/container/src/test/java/org/codehaus/cargo/container/property/ResourceConverterTest.java
@@ -60,6 +60,7 @@ public class ResourceConverterTest extends TestCase
         props.setProperty(ResourcePropertySet.RESOURCE_NAME, "jdbc/JiraDS");
         props.setProperty(ResourcePropertySet.RESOURCE_TYPE, ConfigurationEntryType.XA_DATASOURCE);
         props.setProperty(ResourcePropertySet.RESOURCE_CLASS, "org.hsqldb.jdbcDriver");
+        props.setProperty(ResourcePropertySet.RESOURCE_ID, "JiraDS");
         Resource ds = resourceConverter.fromProperties(props);
         assertEquals(0, ds.getParameters().size());
         assertEquals(props, resourceConverter.toProperties(ds));


### PR DESCRIPTION
So far it wasn't possible to set resource id which is needed to be provided in some containers:
Property name in Resource class holds information about JNDI name, which is complicated to be used for this because of special characters used in it (like /).

This patch brings possibility to set our own resource id or used one generated from JNDI name - similar implementation as is used now in creating datasource id.