### PR TITLE
Adding JMS Resource support for Weblogic container

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/configuration/builder/ConfigurationEntryType.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/configuration/builder/ConfigurationEntryType.java
@@ -60,4 +60,8 @@ public interface ConfigurationEntryType
      */
     String JMS_QUEUE = "javax.jms.Queue";
 
+    /**
+     * JMS connection factory.
+     */
+    String JMS_CONNECTION_FACTORY = "javax.jms.ConnectionFactory";
 }

--- a/core/api/generic/src/main/java/org/codehaus/cargo/generic/AbstractFactoryRegistry.java
+++ b/core/api/generic/src/main/java/org/codehaus/cargo/generic/AbstractFactoryRegistry.java
@@ -31,6 +31,7 @@ import org.apache.commons.discovery.tools.Service;
 import org.codehaus.cargo.container.internal.util.ResourceUtils;
 import org.codehaus.cargo.generic.configuration.ConfigurationCapabilityFactory;
 import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.codehaus.cargo.generic.configuration.builder.ConfigurationBuilderFactory;
 import org.codehaus.cargo.generic.deployable.DeployableFactory;
 import org.codehaus.cargo.generic.deployer.DeployerFactory;
 import org.codehaus.cargo.generic.packager.PackagerFactory;
@@ -164,6 +165,20 @@ public abstract class AbstractFactoryRegistry
     }
 
     /**
+     * See {@link #register(ClassLoader, DeployableFactory)} for the semantics.
+     *
+     * @param classLoader See {@link #register(ClassLoader, DeployableFactory)} for the semantics.
+     * @param factory See {@link #register(ClassLoader, DeployableFactory)} for the semantics.
+     */
+    public static void register(ClassLoader classLoader, ConfigurationBuilderFactory factory)
+    {
+        for (AbstractFactoryRegistry registry : list(classLoader))
+        {
+            registry.register(factory);
+        }
+    }
+
+    /**
      * Registers {@link org.codehaus.cargo.container.deployable.Deployable} implementations to the
      * given {@link DeployableFactory}.
      * 
@@ -212,6 +227,16 @@ public abstract class AbstractFactoryRegistry
      * @param factory See {@link #register(DeployableFactory)}
      */
     protected abstract void register(ContainerCapabilityFactory factory);
+
+    /**
+     * See {@link #register(DeployableFactory)} for the semantics.
+     * Empty default implementation as lot of containers don't support resources.
+     *
+     * @param factory See {@link #register(DeployableFactory)}
+     */
+    protected void register(ConfigurationBuilderFactory factory)
+    {
+    }
 
     /**
      * Lists up {@link AbstractFactoryRegistry}s that are discovered.

--- a/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/ConfigurationBuilderFactory.java
+++ b/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/ConfigurationBuilderFactory.java
@@ -1,0 +1,65 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.generic.configuration.builder;
+
+import org.codehaus.cargo.container.ContainerType;
+import org.codehaus.cargo.container.LocalContainer;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Allow instantiating a configuration builder by id and resource type.
+ */
+public interface ConfigurationBuilderFactory
+{
+
+    /**
+     * Registers a configuration builder implementation.
+     *
+     * @param containerId the container id attached to this configuration class
+     * @param containerType the container type attached to this configuration class
+     * @param configurationEntryType the type to differentiate this configuration entry (Resource)
+     *            from others for the specified container
+     * @param configurationBuilderClass the configuration builder implementation class to register
+     */
+    void registerConfigurationBuilder(String containerId, ContainerType containerType,
+        String configurationEntryType,
+        Class< ? extends ConfigurationBuilder> configurationBuilderClass);
+
+    /**
+     * @param containerId the container id attached to this configuration class
+     * @param containerType the container type attached to this configuration class
+     * @param configurationEntryType the type to differentiate this configuration entry ((Resource))
+     *            from others for the specified container
+     * @return true if the specified configuration is already registered or false otherwise
+     */
+    boolean isConfigurationBuilderRegistered(String containerId, ContainerType containerType,
+        String configurationEntryType);
+
+    /**
+     * Create a configuration instance matching the specified container and type.
+     *
+     * @param container container instance carrying all needed informations for configuration
+     *            builder
+     * @param resource resource which will be built by this configuration builder
+     * @return the configuration builder instance
+     */
+    ConfigurationBuilder createConfigurationBuilder(LocalContainer container, Resource resource);
+}

--- a/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/ConfigurationBuilderFactory.java
+++ b/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/ConfigurationBuilderFactory.java
@@ -44,6 +44,8 @@ public interface ConfigurationBuilderFactory
         Class< ? extends ConfigurationBuilder> configurationBuilderClass);
 
     /**
+     * Check if configuration builder for this container and configuration entry is defined.
+     *
      * @param containerId the container id attached to this configuration class
      * @param containerType the container type attached to this configuration class
      * @param configurationEntryType the type to differentiate this configuration entry ((Resource))

--- a/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/DefaultConfigurationBuilderFactory.java
+++ b/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/DefaultConfigurationBuilderFactory.java
@@ -1,0 +1,171 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.generic.configuration.builder;
+
+import java.lang.reflect.Constructor;
+
+import org.codehaus.cargo.container.ContainerException;
+import org.codehaus.cargo.container.ContainerType;
+import org.codehaus.cargo.container.LocalContainer;
+import org.codehaus.cargo.container.configuration.Configuration;
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+import org.codehaus.cargo.generic.AbstractFactoryRegistry;
+import org.codehaus.cargo.generic.internal.util.FullContainerIdentity;
+import org.codehaus.cargo.generic.internal.util.RegistrationKey;
+import org.codehaus.cargo.generic.spi.AbstractIntrospectionGenericHintFactory;
+
+/**
+ * Default implementation of {@link ConfigurationBuilderFactory}. Registers all known containers.
+ */
+public class DefaultConfigurationBuilderFactory extends
+    AbstractIntrospectionGenericHintFactory<ConfigurationBuilder> implements
+    ConfigurationBuilderFactory
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.codehaus.cargo.generic.spi.AbstractGenericHintFactory.GenericParameters
+     */
+    private static class ConfigurationBuilderFactoryParameters implements GenericParameters
+    {
+        /**
+         * Configuration carrying informations about how/where to put configuration changes to.
+         */
+        public LocalConfiguration configuration;
+    }
+
+    /**
+     * Register default configuration builders.
+     */
+    public DefaultConfigurationBuilderFactory()
+    {
+        this(null);
+    }
+
+    /**
+     * Register configuration name mappings.
+     *
+     * @param classLoader ClassLoader to discover implementations from. See
+     *            {@link AbstractFactoryRegistry#register(ClassLoader, ConfigurationFactory)} for
+     *            the details of what this value means.
+     */
+    public DefaultConfigurationBuilderFactory(ClassLoader classLoader)
+    {
+        super();
+
+        AbstractFactoryRegistry.register(classLoader, this);
+    }
+
+    @Override
+    public void registerConfigurationBuilder(String containerId, ContainerType containerType,
+        String configurationEntryType,
+        Class< ? extends ConfigurationBuilder> configurationBuilderClass)
+    {
+        registerImplementation(new RegistrationKey(new FullContainerIdentity(containerId,
+            containerType), configurationEntryType), configurationBuilderClass);
+
+    }
+
+    @Override
+    public boolean isConfigurationBuilderRegistered(String containerId,
+        ContainerType containerType, String configurationEntryType)
+    {
+        return hasMapping(new RegistrationKey(new FullContainerIdentity(containerId,
+            containerType), configurationEntryType));
+    }
+
+    @Override
+    public ConfigurationBuilder createConfigurationBuilder(LocalContainer container,
+        Resource resource)
+    {
+
+        ConfigurationBuilder configurationBuilder;
+
+        String resourceType = resource.getType();
+
+        if (isConfigurationBuilderRegistered(container.getId(), container.getType(), resourceType))
+        {
+            getLogger().debug("Creating configuration builder for [" + resourceType + "] ",
+                this.getClass().getName());
+
+            ConfigurationBuilderFactoryParameters parameters =
+                new ConfigurationBuilderFactoryParameters();
+            parameters.configuration = container.getConfiguration();
+
+            configurationBuilder =
+                createImplementation(
+                    new RegistrationKey(new FullContainerIdentity(container.getId(),
+                        container.getType()), resourceType), parameters, "configuration builder");
+        }
+        else
+        {
+            throw new ContainerException("There's no registered conf. builder matching your "
+                + "resource [" + resourceType + "]");
+        }
+
+        return configurationBuilder;
+    }
+
+    @Override
+    protected Constructor< ? extends ConfigurationBuilder> getConstructor(
+        Class< ? extends ConfigurationBuilder> configurationBuilderClass, String hint,
+        GenericParameters parameters)
+        throws NoSuchMethodException
+    {
+
+        Constructor< ? extends ConfigurationBuilder> result = null;
+
+        Constructor< ? >[] constructors = configurationBuilderClass.getConstructors();
+        for (Constructor< ? > constructor : constructors)
+        {
+            Class< ? >[] parameterTypes = constructor.getParameterTypes();
+            if (parameterTypes != null && parameterTypes.length == 1)
+            {
+                Class< ? > parameter = parameterTypes[0];
+                if (LocalConfiguration.class.isAssignableFrom(parameter))
+                {
+                    result = (Constructor< ? extends ConfigurationBuilder>) constructor;
+                    break;
+                }
+            }
+        }
+
+        if (result == null)
+        {
+            throw new NoSuchMethodException("No constructor found on class "
+                + configurationBuilderClass + " for configuration builder for resource type ["
+                + hint + "]");
+        }
+        return result;
+    }
+
+    @Override
+    protected ConfigurationBuilder createInstance(
+        Constructor< ? extends ConfigurationBuilder> constructor, String hint,
+        GenericParameters parameters) throws Exception
+    {
+        Configuration configuration =
+            ((ConfigurationBuilderFactoryParameters) parameters).configuration;
+        return constructor.newInstance(new Object[] {configuration});
+    }
+
+}

--- a/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/DefaultConfigurationBuilderFactory.java
+++ b/core/api/generic/src/main/java/org/codehaus/cargo/generic/configuration/builder/DefaultConfigurationBuilderFactory.java
@@ -75,7 +75,11 @@ public class DefaultConfigurationBuilderFactory extends
         AbstractFactoryRegistry.register(classLoader, this);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     *
+     * @see ConfigurationBuilderFactory#registerConfigurationBuilder
+     */
     public void registerConfigurationBuilder(String containerId, ContainerType containerType,
         String configurationEntryType,
         Class< ? extends ConfigurationBuilder> configurationBuilderClass)
@@ -85,7 +89,11 @@ public class DefaultConfigurationBuilderFactory extends
 
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     *
+     * @see ConfigurationBuilderFactory#isConfigurationBuilderRegistered
+     */
     public boolean isConfigurationBuilderRegistered(String containerId,
         ContainerType containerType, String configurationEntryType)
     {
@@ -93,7 +101,11 @@ public class DefaultConfigurationBuilderFactory extends
             containerType), configurationEntryType));
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     *
+     * @see ConfigurationBuilderFactory#createConfigurationBuilder
+     */
     public ConfigurationBuilder createConfigurationBuilder(LocalContainer container,
         Resource resource)
     {

--- a/core/api/generic/src/test/java/org/codehaus/cargo/generic/TestFactoryRegistry.java
+++ b/core/api/generic/src/test/java/org/codehaus/cargo/generic/TestFactoryRegistry.java
@@ -24,6 +24,7 @@ import org.codehaus.cargo.container.configuration.ConfigurationType;
 import org.codehaus.cargo.container.deployable.DeployableType;
 import org.codehaus.cargo.generic.configuration.ConfigurationCapabilityFactory;
 import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.codehaus.cargo.generic.configuration.builder.ConfigurationBuilderFactory;
 import org.codehaus.cargo.generic.deployable.DeployableFactory;
 import org.codehaus.cargo.generic.deployer.DeployerFactory;
 import org.codehaus.cargo.generic.packager.PackagerFactory;
@@ -69,6 +70,11 @@ public class TestFactoryRegistry extends AbstractFactoryRegistry
 
     @Override
     protected void register(ContainerCapabilityFactory factory)
+    {
+    }
+
+    @Override
+    protected void register(ConfigurationBuilderFactory factory)
     {
     }
 }

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
@@ -27,7 +27,9 @@ import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
 import org.codehaus.cargo.container.configuration.entry.DataSource;
 import org.codehaus.cargo.container.configuration.entry.Resource;
 import org.codehaus.cargo.container.spi.configuration.AbstractStandaloneLocalConfiguration;
-import org.codehaus.cargo.container.weblogic.internal.WebLogic8xConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.util.PriorityComparator;
+import org.codehaus.cargo.generic.configuration.builder.ConfigurationBuilderFactory;
+import org.codehaus.cargo.generic.configuration.builder.DefaultConfigurationBuilderFactory;
 
 /**
  * Contains common Weblogic configuration functionality for WLST.
@@ -60,6 +62,7 @@ public abstract class AbstractWebLogicWlstStandaloneLocalConfiguration extends
     {
         super.configure(container);
         configureDataSources(container);
+        sortResources();
         configureResources(container);
     }
 
@@ -105,6 +108,16 @@ public abstract class AbstractWebLogicWlstStandaloneLocalConfiguration extends
     }
 
     /**
+     * Sort resource list because some resources needs to have another resources created first.
+     */
+    protected void sortResources()
+    {
+        PriorityComparator priorityComparator = new PriorityComparator();
+        List<Resource> resources = getResources();
+        resources.sort(priorityComparator);
+    }
+
+    /**
      * Configure resources.
      *
      * @param container Container the datasource will be configured on.
@@ -132,16 +145,20 @@ public abstract class AbstractWebLogicWlstStandaloneLocalConfiguration extends
     }
 
     /**
-     * Returns configuration script for datasource.
+     * Returns configuration script for resource.
      *
      * @param resource Resource to be configured.
-     * @param container Container the dataSource will be configured on.
+     * @param container Container the resource will be configured on.
      * @return Configuration script.
      */
     protected String configure(Resource resource, LocalContainer container)
     {
-        throw new UnsupportedOperationException(
-            WebLogic8xConfigurationBuilder.RESOURCE_CONFIGURATION_UNSUPPORTED);
+        ConfigurationBuilderFactory configurationBuilderFactory =
+            new DefaultConfigurationBuilderFactory();
+        ConfigurationBuilder builder =
+            configurationBuilderFactory.createConfigurationBuilder(container, resource);
+        String configurationEntry = builder.toConfigurationEntry(resource);
+        return configurationEntry;
     }
 
     /**

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/AbstractWebLogicWlstStandaloneLocalConfiguration.java
@@ -20,6 +20,7 @@
 package org.codehaus.cargo.container.weblogic;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.codehaus.cargo.container.LocalContainer;
@@ -114,7 +115,7 @@ public abstract class AbstractWebLogicWlstStandaloneLocalConfiguration extends
     {
         PriorityComparator priorityComparator = new PriorityComparator();
         List<Resource> resources = getResources();
-        resources.sort(priorityComparator);
+        Collections.sort(resources, priorityComparator);
     }
 
     /**

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfiguration.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfiguration.java
@@ -28,9 +28,9 @@ import org.codehaus.cargo.container.configuration.ConfigurationCapability;
 import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
 import org.codehaus.cargo.container.property.GeneralPropertySet;
 import org.codehaus.cargo.container.property.ServletPropertySet;
-import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xDataSourceConfigurationBuilder;
-import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability;
 import org.codehaus.cargo.container.weblogic.internal.WebLogicLocalContainer;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xDataSourceConfigurationBuilder;
 
 /**
  * WebLogic 12.1.x standalone
@@ -64,7 +64,7 @@ public class WebLogic121xWlstStandaloneLocalConfiguration extends
      */
     public ConfigurationCapability getCapability()
     {
-        return new WebLogic9x10x103x12xStandaloneLocalConfigurationCapability();
+        return new WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability();
     }
 
     /**

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogicFactoryRegistry.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/WebLogicFactoryRegistry.java
@@ -23,14 +23,22 @@ import org.codehaus.cargo.container.ContainerType;
 import org.codehaus.cargo.container.configuration.ConfigurationType;
 import org.codehaus.cargo.container.deployer.DeployerType;
 import org.codehaus.cargo.container.internal.J2EEContainerCapability;
-import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xStandaloneLocalConfigurationCapability;
-import org.codehaus.cargo.container.weblogic.internal.WebLogicExistingLocalConfigurationCapability;
 import org.codehaus.cargo.container.weblogic.internal.WebLogic8xStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.WebLogicExistingLocalConfigurationCapability;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xJmsQueueConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xJmsServerConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WeblogicConfigurationEntryType;
 import org.codehaus.cargo.generic.AbstractFactoryRegistry;
 import org.codehaus.cargo.generic.ContainerCapabilityFactory;
 import org.codehaus.cargo.generic.ContainerFactory;
 import org.codehaus.cargo.generic.configuration.ConfigurationCapabilityFactory;
 import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.codehaus.cargo.generic.configuration.builder.ConfigurationBuilderFactory;
 import org.codehaus.cargo.generic.deployable.DeployableFactory;
 import org.codehaus.cargo.generic.deployer.DeployerFactory;
 import org.codehaus.cargo.generic.packager.PackagerFactory;
@@ -97,7 +105,7 @@ public class WebLogicFactoryRegistry extends AbstractFactoryRegistry
 
         configurationCapabilityFactory.registerConfigurationCapability("weblogic121x",
             ContainerType.INSTALLED, ConfigurationType.STANDALONE,
-            WebLogic9x10x103x12xStandaloneLocalConfigurationCapability.class);
+            WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability.class);
         configurationCapabilityFactory.registerConfigurationCapability("weblogic121x",
             ContainerType.INSTALLED, ConfigurationType.EXISTING,
             WebLogicExistingLocalConfigurationCapability.class);
@@ -240,4 +248,33 @@ public class WebLogicFactoryRegistry extends AbstractFactoryRegistry
             J2EEContainerCapability.class);
     }
 
+    /**
+     * Register configuration builder for creating resources.
+     *
+     * @param configurationBuilderFactory Factory on which to register.
+     */
+    @Override
+    protected void register(ConfigurationBuilderFactory configurationBuilderFactory)
+    {
+        // Resources for Weblogic 12.1.x.
+        configurationBuilderFactory.registerConfigurationBuilder("weblogic121x",
+            ContainerType.INSTALLED, WeblogicConfigurationEntryType.JMS_CONNECTION_FACTORY,
+            WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder.class);
+
+        configurationBuilderFactory.registerConfigurationBuilder("weblogic121x",
+            ContainerType.INSTALLED, WeblogicConfigurationEntryType.JMS_MODULE,
+            WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder.class);
+
+        configurationBuilderFactory.registerConfigurationBuilder("weblogic121x",
+            ContainerType.INSTALLED, WeblogicConfigurationEntryType.JMS_QUEUE,
+            WebLogic9x10x103x12xJmsQueueConfigurationBuilder.class);
+
+        configurationBuilderFactory.registerConfigurationBuilder("weblogic121x",
+            ContainerType.INSTALLED, WeblogicConfigurationEntryType.JMS_SERVER,
+            WebLogic9x10x103x12xJmsServerConfigurationBuilder.class);
+
+        configurationBuilderFactory.registerConfigurationBuilder("weblogic121x",
+            ContainerType.INSTALLED, WeblogicConfigurationEntryType.JMS_SUBDEPLOYMENT,
+            WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder.class);
+    }
 }

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability.java
@@ -1,0 +1,43 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal;
+
+import org.codehaus.cargo.container.property.ResourcePropertySet;
+
+/**
+ * Capabilities of Weblogic(what it can do and what can be set).
+ */
+public class WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability extends
+    WebLogic9x10x103x12xStandaloneLocalConfigurationCapability
+{
+
+    /**
+     * WLST implementation allows easy support of resources.
+     */
+    public WebLogic9x10x103x12xWlstStandaloneLocalConfigurationCapability()
+    {
+        super();
+
+        // support resources
+        this.supportsMap.put(ResourcePropertySet.RESOURCE, Boolean.TRUE);
+        this.supportsMap.put(ResourcePropertySet.RESOURCE_NAME, Boolean.TRUE);
+        this.supportsMap.put(ResourcePropertySet.RESOURCE_TYPE, Boolean.TRUE);
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/AbstractWebLogicJmsConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/AbstractWebLogicJmsConfigurationBuilder.java
@@ -104,7 +104,9 @@ public abstract class AbstractWebLogicJmsConfigurationBuilder implements Configu
         return configuration.getPropertyValue(WebLogicPropertySet.SERVER);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(DataSource ds)
     {
         throw new UnsupportedOperationException("Datasource configuration unsupported in this "

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/AbstractWebLogicJmsConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/AbstractWebLogicJmsConfigurationBuilder.java
@@ -1,0 +1,113 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.builder.ConfigurationBuilder;
+import org.codehaus.cargo.container.configuration.entry.DataSource;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
+import org.codehaus.cargo.util.CargoException;
+
+/**
+ * Class holding common properties for JMS resource builders.
+ */
+public abstract class AbstractWebLogicJmsConfigurationBuilder implements ConfigurationBuilder
+{
+    /**
+     * New line constant.
+     */
+    protected static final String NEW_LINE = System.getProperty("line.separator");
+
+    /**
+     * Configuration containing all needed informations.
+     */
+    private LocalConfiguration configuration;
+
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public AbstractWebLogicJmsConfigurationBuilder(LocalConfiguration configuration)
+    {
+        this.configuration = configuration;
+    }
+
+    /**
+     * @return Jms server name.
+     */
+    protected String getJmsServerName()
+    {
+        for (Resource resource : configuration.getResources())
+        {
+            if (WeblogicConfigurationEntryType.JMS_SERVER.equals(resource.getType()))
+            {
+                return resource.getId();
+            }
+        }
+        throw new CargoException("No JMS server resource found.");
+    }
+
+    /**
+     * @return Jms subdeployment name.
+     */
+    protected String getJmsSubdeploymentName()
+    {
+        for (Resource resource : configuration.getResources())
+        {
+            if (WeblogicConfigurationEntryType.JMS_SUBDEPLOYMENT.equals(resource.getType()))
+            {
+                return resource.getId();
+            }
+        }
+        throw new CargoException("No JMS subdeployment resource found.");
+    }
+
+    /**
+     * @return Jms module name.
+     */
+    protected String getJmsModuleName()
+    {
+        for (Resource resource : configuration.getResources())
+        {
+            if (WeblogicConfigurationEntryType.JMS_MODULE.equals(resource.getType()))
+            {
+                return resource.getId();
+            }
+        }
+        throw new CargoException("No JMS subdeployment resource found.");
+    }
+
+    /**
+     * @return Server name.
+     */
+    protected String getServerName()
+    {
+        return configuration.getPropertyValue(WebLogicPropertySet.SERVER);
+    }
+
+    @Override
+    public String toConfigurationEntry(DataSource ds)
+    {
+        throw new UnsupportedOperationException("Datasource configuration unsupported in this "
+            + "configuration builder.");
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xDataSourceConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xDataSourceConfigurationBuilder.java
@@ -17,7 +17,7 @@
  *
  * ========================================================================
  */
-package org.codehaus.cargo.container.weblogic.internal;
+package org.codehaus.cargo.container.weblogic.internal.configuration;
 
 import java.util.Map.Entry;
 import java.util.Set;
@@ -27,6 +27,7 @@ import org.codehaus.cargo.container.configuration.builder.ConfigurationEntryType
 import org.codehaus.cargo.container.configuration.entry.DataSource;
 import org.codehaus.cargo.container.property.TransactionSupport;
 import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
+import org.codehaus.cargo.container.weblogic.internal.WebLogic9x10x103x12xConfigurationBuilder;
 
 /**
  * Create WLST script for adding DataSource to Weblogic domain.

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Create WLST script for adding JMS connection factory to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder extends
+    AbstractWebLogicJmsConfigurationBuilder
+{
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder(
+        LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String toConfigurationEntry(Resource resource)
+    {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("cd('JMSSystemResource/%s/JmsResource/NO_NAME_0')",
+            getJmsModuleName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("cf=create('%s','ConnectionFactory')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("cf.setJNDIName('%s')", resource.getName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("cf.setSubDeploymentName('%s')", getJmsSubdeploymentName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("cd('ConnectionFactories/%s')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("tp=create('%s','TransactionParams')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append("tp.setXAConnectionFactoryEnabled(true)");
+
+        return buffer.toString();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder.java
@@ -39,7 +39,9 @@ public class WebLogic9x10x103x12xJmsConnectionFactoryConfigurationBuilder extend
         super(configuration);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(Resource resource)
     {
         StringBuffer buffer = new StringBuffer();

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsQueueConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsQueueConfigurationBuilder.java
@@ -38,7 +38,9 @@ public class WebLogic9x10x103x12xJmsQueueConfigurationBuilder extends
         super(configuration);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(Resource resource)
     {
         StringBuffer buffer = new StringBuffer();

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsQueueConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsQueueConfigurationBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Create WLST script for adding JMS queue to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xJmsQueueConfigurationBuilder extends
+    AbstractWebLogicJmsConfigurationBuilder
+{
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public WebLogic9x10x103x12xJmsQueueConfigurationBuilder(LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String toConfigurationEntry(Resource resource)
+    {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("cd('JMSSystemResource/%s/JmsResource/NO_NAME_0')",
+            getJmsModuleName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("myq=create('%s','Queue')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("myq.setJNDIName('%s')", resource.getName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("myq.setSubDeploymentName('%s')", getJmsSubdeploymentName()));
+
+        return buffer.toString();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsServerConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsServerConfigurationBuilder.java
@@ -38,7 +38,9 @@ public class WebLogic9x10x103x12xJmsServerConfigurationBuilder extends
         super(configuration);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(Resource resource)
     {
         StringBuffer buffer = new StringBuffer();

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsServerConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsServerConfigurationBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Create WLST script for adding JMS server to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xJmsServerConfigurationBuilder extends
+    AbstractWebLogicJmsConfigurationBuilder
+{
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public WebLogic9x10x103x12xJmsServerConfigurationBuilder(LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String toConfigurationEntry(Resource resource)
+    {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("create('%s', 'JMSServer')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append("cd('/')");
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("assign('JMSServer', '%s', 'Target', '%s')",
+            resource.getId(), getServerName()));
+
+        return buffer.toString();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder.java
@@ -39,7 +39,9 @@ public class WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder extends
         super(configuration);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(Resource resource)
     {
         StringBuffer buffer = new StringBuffer();

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Create WLST script for adding JMS subdeployment to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder extends
+    AbstractWebLogicJmsConfigurationBuilder
+{
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public WebLogic9x10x103x12xJmsSubdeploymentConfigurationBuilder(
+        LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String toConfigurationEntry(Resource resource)
+    {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("cd('JMSSystemResource/%s')", getJmsModuleName()));
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("create('%s', 'SubDeployment')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append("cd('/')");
+        buffer.append(NEW_LINE);
+        buffer.append(String.format(
+            "assign('JMSSystemResource.SubDeployment', '%s', 'Target', '%s')",
+            resource.getId(), getJmsServerName()));
+
+        return buffer.toString();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.configuration.entry.Resource;
+
+/**
+ * Create WLST script for adding JMS system resource to Weblogic domain.
+ */
+public class WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder extends
+    AbstractWebLogicJmsConfigurationBuilder
+{
+    /**
+     * Sets configuration containing all needed information for building JMS resources.
+     *
+     * @param configuration containing all needed informations.
+     */
+    public WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder(
+        LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String toConfigurationEntry(Resource resource)
+    {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(String.format("create('%s', 'JMSSystemResource')", resource.getId()));
+        buffer.append(NEW_LINE);
+        buffer.append("cd('/')");
+        buffer.append(NEW_LINE);
+        buffer.append(String.format("assign('JMSSystemResource', '%s', 'Target', '%s')",
+            resource.getId(), getServerName()));
+
+        return buffer.toString();
+    }
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder.java
@@ -39,7 +39,9 @@ public class WebLogic9x10x103x12xJmsSystemResourceConfigurationBuilder extends
         super(configuration);
     }
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public String toConfigurationEntry(Resource resource)
     {
         StringBuffer buffer = new StringBuffer();

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WeblogicConfigurationEntryType.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/WeblogicConfigurationEntryType.java
@@ -1,0 +1,44 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration;
+
+import org.codehaus.cargo.container.configuration.builder.ConfigurationEntryType;
+
+/**
+ * Represents the type of a resource specific to Weblogic, such as a <code>javax.jms.Server</code>.
+ */
+public interface WeblogicConfigurationEntryType extends ConfigurationEntryType
+{
+
+    /**
+     * JMS server.
+     */
+    String JMS_SERVER = "javax.jms.Server";
+
+    /**
+     * JMS module.
+     */
+    String JMS_MODULE = "javax.jms.Module";
+
+    /**
+     * JMS subdeployment.
+     */
+    String JMS_SUBDEPLOYMENT = "javax.jms.Subdeployment";
+}

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/util/PriorityComparator.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/util/PriorityComparator.java
@@ -30,7 +30,9 @@ import org.codehaus.cargo.util.CargoException;
 public class PriorityComparator implements Comparator<Resource>
 {
 
-    @Override
+    /**
+     * {@inheritDoc}
+     */
     public int compare(Resource firstResource, Resource secondResource)
     {
         String firstResourcePriority = firstResource.getParameter("priority");

--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/util/PriorityComparator.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/configuration/util/PriorityComparator.java
@@ -1,0 +1,68 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2011-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.weblogic.internal.configuration.util;
+
+import java.util.Comparator;
+
+import org.codehaus.cargo.container.configuration.entry.Resource;
+import org.codehaus.cargo.util.CargoException;
+
+/**
+ * Comparator evaluating resources according to their priority.
+ */
+public class PriorityComparator implements Comparator<Resource>
+{
+
+    @Override
+    public int compare(Resource firstResource, Resource secondResource)
+    {
+        String firstResourcePriority = firstResource.getParameter("priority");
+        String secondResourcePriority = secondResource.getParameter("priority");
+
+        if (firstResourcePriority == null && secondResourcePriority == null)
+        {
+            return 0;
+        }
+
+        if (firstResourcePriority == null)
+        {
+            return 1;
+        }
+
+        if (secondResourcePriority == null)
+        {
+            return -1;
+        }
+
+        Integer firstResourcePriorityValue = null;
+        Integer secondResourcePriorityValue = null;
+        try
+        {
+            firstResourcePriorityValue = Integer.valueOf(firstResourcePriority);
+            secondResourcePriorityValue = Integer.valueOf(secondResourcePriority);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new CargoException("Priority parameter has to be integer value.");
+        }
+
+        return firstResourcePriorityValue.compareTo(secondResourcePriorityValue);
+    }
+}

--- a/core/containers/weblogic/src/test/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfigurationTest.java
+++ b/core/containers/weblogic/src/test/java/org/codehaus/cargo/container/weblogic/WebLogic121xWlstStandaloneLocalConfigurationTest.java
@@ -1,0 +1,92 @@
+package org.codehaus.cargo.container.weblogic;
+
+import java.util.List;
+
+import org.codehaus.cargo.container.configuration.entry.Resource;
+import org.codehaus.cargo.container.weblogic.internal.configuration.WeblogicConfigurationEntryType;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for {@link WebLogic121xWlstStandaloneLocalConfiguration}.
+ */
+public class WebLogic121xWlstStandaloneLocalConfigurationTest extends TestCase
+{
+    /**
+     * BEA_HOME
+     */
+    private static final String BEA_HOME = "ram:/bea";
+
+    /**
+     * DOMAIN_HOME
+     */
+    private static final String DOMAIN_HOME = BEA_HOME + "/mydomain";
+
+    /**
+     * WL_HOME
+     */
+    private static final String WL_HOME = BEA_HOME + "/wlserver";
+
+    /**
+     * Container.
+     */
+    private WebLogic121xWlstInstalledLocalContainer container;
+
+    /**
+     * Configuration.
+     */
+    private WebLogic121xWlstStandaloneLocalConfiguration configuration;
+
+    /**
+     * Creates the test file system manager and the container. {@inheritDoc}
+     *
+     * @throws Exception If anything goes wrong.
+     */
+    @Override
+    protected void setUp() throws Exception
+    {
+        super.setUp();
+
+        this.configuration = new WebLogic121xWlstStandaloneLocalConfiguration(DOMAIN_HOME);
+
+        this.container = new WebLogic121xWlstInstalledLocalContainer(configuration);
+        this.container.setHome(WL_HOME);
+    }
+
+    /**
+     * Test sorting of resources. Resources should be sorted according to their priority set in
+     * properties.
+     *
+     * @throws Exception If anything goes wrong.
+     */
+    public void testSortResources() throws Exception
+    {
+        Resource jmsServer =
+            new Resource("TestJmsServer", WeblogicConfigurationEntryType.JMS_SERVER);
+        jmsServer.setParameter("priority", "10");
+        Resource jmsModule =
+            new Resource("TestJmsModule", WeblogicConfigurationEntryType.JMS_MODULE);
+        jmsModule.setParameter("priority", "20");
+        Resource jmsSubdeployment =
+            new Resource("TestJmsSubdeployment", WeblogicConfigurationEntryType.JMS_SUBDEPLOYMENT);
+        jmsSubdeployment.setParameter("priority", "30");
+        Resource jmsQueue =
+            new Resource("jms/queue/REQUEST", WeblogicConfigurationEntryType.JMS_QUEUE);
+
+        // adding resources in random order
+        configuration.addResource(jmsSubdeployment);
+        configuration.addResource(jmsQueue);
+        configuration.addResource(jmsModule);
+        configuration.addResource(jmsServer);
+
+        configuration.sortResources();
+
+        // resources are sorted according to priority
+        List<Resource> resources = configuration.getResources();
+        assertEquals(4, resources.size());
+        assertEquals(WeblogicConfigurationEntryType.JMS_SERVER, resources.get(0).getType());
+        assertEquals(WeblogicConfigurationEntryType.JMS_MODULE, resources.get(1).getType());
+        assertEquals(WeblogicConfigurationEntryType.JMS_SUBDEPLOYMENT, resources.get(2).getType());
+        assertEquals(WeblogicConfigurationEntryType.JMS_QUEUE, resources.get(3).getType());
+    }
+}


### PR DESCRIPTION
Hello,

This is my idea of how Weblogic resource configuration implementation could look. It is implemented by using dedicated configuration builder for every resource supported - so far just JMS - which is bound to specific resource in WebLogicFactoryRegistry.
Some resources have to be created before others, so they are sorted first.

What do you think about this?