### PR TITLE
CARGO-1373 : fix Tomcat 8 webapp containing META-INF/context.xml and …

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat5xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat5xStandaloneLocalConfiguration.java
@@ -38,6 +38,7 @@ import org.codehaus.cargo.container.property.ServletPropertySet;
 import org.codehaus.cargo.container.tomcat.internal.AbstractCatalinaStandaloneLocalConfiguration;
 import org.codehaus.cargo.container.tomcat.internal.Tomcat5x6x7xConfigurationBuilder;
 import org.codehaus.cargo.container.tomcat.internal.Tomcat5x6xStandaloneLocalConfigurationCapability;
+import org.dom4j.Element;
 
 /**
  * StandAloneLocalConfiguration that is appropriate for Tomcat 5.x containers.
@@ -322,6 +323,17 @@ public class Tomcat5xStandaloneLocalConfiguration extends
         getLogger().warn("Tomcat 5.x doesn't support extra classpath on WARs",
             this.getClass().getName());
         return "";
+    }
+    
+    /**
+     * Configures the specified context element with the extra classpath (if any) of the given WAR.
+     * @param deployable Deployable to create extra classpath XML token for.
+     * @param context The context element to configure, must not be {@code null}.
+     */
+    protected void configureExtraClasspathToken(WAR deployable, Element context)
+    {
+        getLogger().warn("Tomcat 5.x doesn't support extra classpath on WARs",
+            this.getClass().getName());
     }
 
     /**

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatCopyingInstalledLocalDeployer.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatCopyingInstalledLocalDeployer.java
@@ -27,7 +27,6 @@ import org.codehaus.cargo.container.deployable.WAR;
 import org.codehaus.cargo.container.property.GeneralPropertySet;
 import org.codehaus.cargo.container.spi.deployer.AbstractCopyingInstalledLocalDeployer;
 import org.codehaus.cargo.container.tomcat.internal.TomcatUtils;
-import org.codehaus.cargo.util.CargoException;
 import org.codehaus.cargo.util.Dom4JUtil;
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -155,35 +154,11 @@ public class TomcatCopyingInstalledLocalDeployer extends AbstractCopyingInstalle
      */
     private void configureExtraClasspath(WAR war, Element context)
     {
-        String extraClasspath = TomcatUtils.getExtraClasspath(war, true);
-        if (extraClasspath != null)
+        if (war.getExtraClasspath() != null)
         {
-            Element loader = context.element("Loader");
-            if (loader == null)
-            {
-                loader = context.addElement("Loader");
-            }
-
-            String className =
-                loader.attributeValue("className", "org.apache.catalina.loader.WebappLoader");
-            if (!"org.apache.catalina.loader.WebappLoader".equals(className)
-                && !"org.apache.catalina.loader.VirtualWebappLoader".equals(className))
-            {
-                throw new CargoException("Extra classpath is not supported"
-                    + " for WARs using custom loader: " + className);
-            }
-            loader.addAttribute("className", "org.apache.catalina.loader.VirtualWebappLoader");
-
-            String virtualClasspath = loader.attributeValue("virtualClasspath", "");
-            if (virtualClasspath.length() <= 0)
-            {
-                virtualClasspath = extraClasspath;
-            }
-            else
-            {
-                virtualClasspath = extraClasspath + ";" + virtualClasspath;
-            }
-            loader.addAttribute("virtualClasspath", virtualClasspath);
+            // if extraClasspath is not null here, we are on tomcat >=5x
+            ((Tomcat5xStandaloneLocalConfiguration) getContainer().getConfiguration())
+                .configureExtraClasspathToken(war, context);
         }
     }
 

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatUtils.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatUtils.java
@@ -66,8 +66,8 @@ public final class TomcatUtils
     public static String getExtraClasspath(WAR war, boolean xml)
     {
         StringBuilder buffer = new StringBuilder(1024);
-        String[] extraClasspath = war.getExtraClasspath();
-        if (extraClasspath == null || extraClasspath.length <= 0)
+        String[] extraClasspath = getExtraClasspath(war);
+        if (extraClasspath == null)
         {
             return null;
         }
@@ -86,5 +86,20 @@ public final class TomcatUtils
         }
         return result;
     }
-
+    
+    /**
+     * Gets the extra classpath for the WAR as a string array
+     * 
+     * @param war The WAR being deployed, must not be {@code null}.
+     * @return The WAR's extra classpath or {@code null} if none.
+     */
+    public static String[] getExtraClasspath(WAR war)
+    {
+        String[] extraClasspath = war.getExtraClasspath();
+        if (extraClasspath == null || extraClasspath.length <= 0)
+        {
+            return null;
+        }
+        return extraClasspath;
+    }
 }

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/WarExtraClasspathWithContextTest.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/WarExtraClasspathWithContextTest.java
@@ -1,0 +1,173 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2015 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.sample.java;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.tools.ant.taskdefs.Copy;
+import org.apache.tools.ant.taskdefs.Expand;
+import org.codehaus.cargo.container.configuration.ConfigurationType;
+import org.codehaus.cargo.container.deployable.DeployableType;
+import org.codehaus.cargo.container.deployable.WAR;
+import org.codehaus.cargo.container.tomcat.TomcatPropertySet;
+import org.codehaus.cargo.generic.deployable.DefaultDeployableFactory;
+import org.codehaus.cargo.sample.java.validator.HasStandaloneConfigurationValidator;
+import org.codehaus.cargo.sample.java.validator.HasWarSupportValidator;
+import org.codehaus.cargo.sample.java.validator.IsInstalledLocalContainerValidator;
+import org.codehaus.cargo.sample.java.validator.StartsWithContainerValidator;
+import org.codehaus.cargo.sample.java.validator.Validator;
+import org.codehaus.cargo.util.AntUtils;
+import org.codehaus.cargo.util.CargoException;
+
+import junit.framework.Test;
+
+/**
+ * Test for WAR extra classpath support with a webapp who contains META-INF/context.xml file.
+ */
+public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
+{
+    /**
+     * Initializes the test case.
+     * 
+     * @param testName Test name.
+     * @param testData Test environment data.
+     * @throws Exception If anything goes wrong.
+     */
+    public WarExtraClasspathWithContextTest(String testName, EnvironmentTestData testData)
+        throws Exception
+    {
+        super(testName, testData);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void setUp() throws Exception
+    {
+        super.setUp();
+        setContainer(createContainer(createConfiguration(ConfigurationType.STANDALONE)));
+    }
+
+    /**
+     * Creates the test suite, using the {@link Validator}s.
+     * 
+     * @return Test suite.
+     * @throws Exception If anything goes wrong.
+     */
+    public static Test suite() throws Exception
+    {
+        CargoTestSuite suite =
+            new CargoTestSuite("Tests that run on local containers to test extra classpath with "
+                + " META-INF/context.xml file");
+
+        Set<String> excludedContainerIds = new TreeSet<String>();
+        excludedContainerIds.add("jetty4x");
+        excludedContainerIds.add("jetty5x");
+        excludedContainerIds.add("tomcat4x");
+        excludedContainerIds.add("tomcat5x");
+        suite.addTestSuite(WarExtraClasspathWithContextTest.class, new Validator[] {
+            new StartsWithContainerValidator("jetty", "tomcat", "tomee"), 
+            new HasWarSupportValidator(), new IsInstalledLocalContainerValidator(),
+            new HasStandaloneConfigurationValidator()},
+            excludedContainerIds);
+        return suite;
+    }
+    
+    /**
+     * Tests that a servlet has access to a class in added to the extraclasspath
+     * with WAR with a <code>context.xml</code> file.
+     * @throws Exception If anything goes wrong.
+     */
+    public void testLoadClassOnWarWithContextXmlFile() throws Exception
+    {
+        // Copies the tomcat context war in order to rename it so that it matches the context
+        // path defined in its context.xml file.
+        File artifactDir = new File(getTestData().targetDir).getParentFile();
+        Copy copyTask = (Copy) new AntUtils().createProject().createTask("copy");
+        copyTask.setTofile(new File(artifactDir, "tomcat-context.war"));
+        copyTask.setFile(new File(getTestData().getTestDataFileFor("tomcatcontext-war")));
+        copyTask.execute();
+        
+        String simpleJar = System.getProperty("cargo.testdata.simple-jar");
+        if (simpleJar == null)
+        {
+            throw new CargoException("Please set property [cargo.testdata.simple-jar] to a valid "
+                + "location of simple-jar");
+        }
+
+        WAR war = (WAR) new DefaultDeployableFactory().createDeployable(getContainer().getId(),
+            new File(artifactDir, "tomcat-context.war").getPath(), DeployableType.WAR);
+        war.setExtraClasspath(new String[] {simpleJar});
+
+        getLocalContainer().getConfiguration().addDeployable(war);
+        getLocalContainer().getConfiguration().setProperty(TomcatPropertySet.COPY_WARS, "false");
+
+        URL warPingURL = new URL("http://localhost:" + getTestData().port + "/tomcat-context/");
+
+        getLocalContainer().start();
+        PingUtils.assertPingTrue("tomcat context war not started", "Test value is [test value]",
+            warPingURL, getLogger());
+
+        getLocalContainer().stop();
+        PingUtils.assertPingFalse("tomcat context war not stopped", warPingURL, getLogger());
+    }
+
+    /**
+     * Tests that a servlet has access to a class in added to the extraclasspath
+     * with expanded WAR with a <code>context.xml</code> file.
+     * @throws Exception If anything goes wrong.
+     */
+    public void testLoadClassOnExpandedWarWithContextXmlFile() throws Exception
+    {
+        // Copy the war from the Maven local repository in order to expand it
+        File artifactDir = new File(getTestData().targetDir).getParentFile();
+        Expand expandTask = (Expand) new AntUtils().createProject().createTask("unwar");
+        expandTask.setDest(new File(artifactDir, "tomcat-context"));
+        expandTask.setSrc(new File(getTestData().getTestDataFileFor("tomcatcontext-war")));
+        expandTask.execute();
+        
+        String simpleJar = System.getProperty("cargo.testdata.simple-jar");
+        if (simpleJar == null)
+        {
+            throw new CargoException("Please set property [cargo.testdata.simple-jar] to a valid "
+                + "location of simple-jar");
+        }
+
+        WAR war = (WAR) new DefaultDeployableFactory().createDeployable(getContainer().getId(),
+            new File(artifactDir, "tomcat-context").getPath(), DeployableType.WAR);
+        war.setExtraClasspath(new String[] {simpleJar});
+
+        getLocalContainer().getConfiguration().addDeployable(war);
+        getLocalContainer().getConfiguration().setProperty(TomcatPropertySet.COPY_WARS, "false");
+
+        URL warPingURL = new URL("http://localhost:" + getTestData().port + "/tomcat-context/");
+
+        getLocalContainer().start();
+        PingUtils.assertPingTrue("tomcat context war not started", "Test value is [test value]",
+            warPingURL, getLogger());
+
+        getLocalContainer().stop();
+        PingUtils.assertPingFalse("tomcat context war not stopped", warPingURL, getLogger());
+    }
+}


### PR DESCRIPTION
…using extraClasspath

According to https://codehaus-cargo.atlassian.net/browse/CARGO-1373, this PR will fix the bug in Tomcat 8 when a context.xml file is present.

This need a refactoring to use extraClasspath token in the tomcat configuration (who follow version) and not in TomcatCopyingInstalledLocalDeployer.java who don't care tomcat version.

I have added a new test who show the problem with context.xml and extraClasspath.