### PR TITLE
 Add support for webjars

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfiguration.java
@@ -39,6 +39,15 @@ public class Tomcat7xStandaloneLocalConfiguration extends Tomcat6xStandaloneLoca
 {
 
     /**
+     * Context tag attribute for allowing multi part.
+     */
+    private static final String CONTEXT_ALLOWMULTIPART_ATTR_NAME = "allowCasualMultipartParsing";
+    /**
+     * Context tag attribute for allowing webjars.
+     */
+    private static final String CONTEXT_ALLOWWEBJARS_ATTR_NAME = "addWebinfClassesResources";
+
+    /**
      * {@inheritDoc}
      * 
      * @see TomcatStandaloneLocalConfigurationCapability
@@ -56,6 +65,7 @@ public class Tomcat7xStandaloneLocalConfiguration extends Tomcat6xStandaloneLoca
 
         setProperty(ServletPropertySet.USERS, "admin::manager-script");
         setProperty(TomcatPropertySet.CONTEXT_ALLOWMULTIPART, "true");
+        setProperty(TomcatPropertySet.CONTEXT_ALLOWWEBJARS, "true");
 
         // CARGO-1271: Starting Tomcat 7 with Cargo logs warning on emptySessionPath
         getProperties().remove(TomcatPropertySet.CONNECTOR_EMPTY_SESSION_PATH);
@@ -136,8 +146,11 @@ public class Tomcat7xStandaloneLocalConfiguration extends Tomcat6xStandaloneLoca
     @Override
     protected String getExtraContextAttributes()
     {
-        return new StringBuilder(" allowCasualMultipartParsing=\"").append(
-            getPropertyValue(TomcatPropertySet.CONTEXT_ALLOWMULTIPART)).append("\"").toString();
+        return new StringBuilder(" ").append(CONTEXT_ALLOWMULTIPART_ATTR_NAME).append("=\"")
+            .append(getPropertyValue(TomcatPropertySet.CONTEXT_ALLOWMULTIPART)).append("\" ")
+            .append(CONTEXT_ALLOWWEBJARS_ATTR_NAME).append("=\"")
+            .append(getPropertyValue(TomcatPropertySet.CONTEXT_ALLOWWEBJARS))
+            .append("\"").toString();
     }
 
     /**

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
@@ -51,6 +51,11 @@ public interface TomcatPropertySet
     String CONTEXT_ALLOWMULTIPART = "cargo.tomcat.context.allowCasualMultipartParsing";
 
     /**
+     * Whether the contexts for deployed webapplications should allow webjars support
+     */
+    String CONTEXT_ALLOWWEBJARS = "cargo.tomcat.context.addWebinfClassesResources";
+
+    /**
      * Whether WAR deployables should be copied or referenced.
      */
     String COPY_WARS = "cargo.tomcat.copywars";

--- a/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfigurationTest.java
+++ b/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfigurationTest.java
@@ -75,6 +75,8 @@ public class Tomcat7xStandaloneLocalConfigurationTest extends
     {
         Assert.assertTrue(Boolean.valueOf(
             configuration.getProperties().get(TomcatPropertySet.CONTEXT_ALLOWMULTIPART)));
+        Assert.assertTrue(Boolean.valueOf(
+            configuration.getProperties().get(TomcatPropertySet.CONTEXT_ALLOWWEBJARS)));
     }
 
 }


### PR DESCRIPTION
 Since servlet 3.0 it's possible to expose some web resource throught jars.
After testing I have see that it was not possible throught cargo with Tomcat.
This commit add support for it. It just set the required attribute "addWebinfClassesResources" to true.
More information on tomcat configuration  :

https://tomcat.apache.org/tomcat-7.0-doc/config/context.html