### PR TITLE
CARGO-1418: Tomcat deploy transfer speed

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
@@ -545,7 +545,7 @@ public class TomcatManager extends LoggedObject
             // When trying to upload large amount of data the internal connection buffer can become
             // too large and exceed the heap size, leading to a java.lang.OutOfMemoryError.
             // This was fixed in JDK 1.5 by introducing a new setChunkedStreamingMode() method.
-            // CARGO-1418 Tomcat deploy transfer speed - use a sensible chunk size for high capacity links
+            // CARGO-1418 Tomcat deploy transfer speed - use a sensible chunk size for fast links
             connection.setChunkedStreamingMode(1024 * 256);
         }
 

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
@@ -535,12 +535,18 @@ public class TomcatManager extends LoggedObject
             connection.setDoOutput(true);
             connection.setRequestMethod("PUT");
             connection.setRequestProperty("Content-Type", "application/octet-stream");
-            connection.setRequestProperty("Expect", "100-continue");
+
+            // CARGO-1418 Tomcat deploy transfer speed
+            // Expect/Continue causes a slowdown in chunked transfer when remotely deploying over
+            // fast links. This may cause faulures (i.e. auth fail) to be be very slow as the
+            //  entire PUT request will be transferred before getting the error response
+            //connection.setRequestProperty("Expect", "100-continue");
 
             // When trying to upload large amount of data the internal connection buffer can become
             // too large and exceed the heap size, leading to a java.lang.OutOfMemoryError.
             // This was fixed in JDK 1.5 by introducing a new setChunkedStreamingMode() method.
-            connection.setChunkedStreamingMode(0);
+            // CARGO-1418 Tomcat deploy transfer speed - use a sensible chunk size for high capacity links
+            connection.setChunkedStreamingMode(1024 * 256);
         }
 
         if (this.userAgent != null)


### PR DESCRIPTION
- remove expect/continue header for PUT requests
- set chunked transfer to use a sensible chunk size