### PR TITLE
CARGO-1441 Support parsing Java 9 version in JdkUtils

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/JdkUtils.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/JdkUtils.java
@@ -120,7 +120,7 @@ public final class JdkUtils
      */
     public static int parseMajorJavaVersion(String version)
     {
-        String jvmVersion = version;
+        String jvmVersion = version.replace("\"", "");
         if (jvmVersion.startsWith("1."))
         {
             jvmVersion = jvmVersion.substring(2);

--- a/core/api/container/src/test/java/org/codehaus/cargo/container/internal/util/JdkUtilsTest.java
+++ b/core/api/container/src/test/java/org/codehaus/cargo/container/internal/util/JdkUtilsTest.java
@@ -1,0 +1,20 @@
+package org.codehaus.cargo.container.internal.util;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for {@link JdkUtils}.
+ */
+public class JdkUtilsTest extends TestCase
+{
+
+    /**
+     * Test parsing major java versions
+     */
+    public void testParseMajorJavaVersion()
+    {
+        assertEquals(7, JdkUtils.parseMajorJavaVersion("1.7.0_3\""));
+        assertEquals(8, JdkUtils.parseMajorJavaVersion("1.8.0_121\""));
+        assertEquals(9, JdkUtils.parseMajorJavaVersion("9\""));
+    }
+}


### PR DESCRIPTION
Supports parsing when AbstractInstalledLocalContainer.createJvmLauncher()
tries to parse the following "java -version" output:

java version "9"
Java(TM) SE Runtime Environment (build 9+181)
Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)

Fixes:

Caused by: java.lang.NumberFormatException: For input string: "9""
        at org.codehaus.cargo.container.internal.util.JdkUtils.parseMajorJavaVersion(JdkUtils.java:138)
        at org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer.createJvmLauncher(AbstractInstalledLocalContainer.java:399)
        at org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer.startInternal(AbstractInstalledLocalContainer.java:287)
        at org.codehaus.cargo.container.spi.AbstractLocalContainer.start(AbstractLocalContainer.java:226)