### PR TITLE
CARGO-1440: Add support for WildFly Swarm

### DIFF
--- a/core/containers/pom.xml
+++ b/core/containers/pom.xml
@@ -72,5 +72,6 @@
     <module>weblogic</module>
     <module>websphere</module>
     <module>wildfly</module>
+    <module>wildfly-swarm</module>
   </modules>
 </project>

--- a/core/containers/wildfly-swarm/pom.xml
+++ b/core/containers/wildfly-swarm/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cargo-core-containers</artifactId>
+    <groupId>org.codehaus.cargo</groupId>
+    <version>1.6.5-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cargo-core-container-wildfly-swarm</artifactId>
+  <name>Cargo Core WildFly Swarm Container</name>
+  <packaging>jar</packaging>
+  <description>Core API implementation for WildFly Swarm containers</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarm2017xInstalledLocalContainer.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarm2017xInstalledLocalContainer.java
@@ -1,0 +1,64 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm;
+
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.wildfly.swarm.internal.
+        AbstractWildFlySwarmInstalledLocalContainer;
+
+/**
+ * WildFly Swarm 2017.x series container implementation.
+ * */
+public class WildFlySwarm2017xInstalledLocalContainer extends
+        AbstractWildFlySwarmInstalledLocalContainer
+{
+    /**
+     * WildFly Swarm 2017.x series unique id.
+     * */
+    static final String CONTAINER_ID = "wildfly-swarm2017x";
+
+    /**
+     * Version String.
+     * */
+    static final String VERSION = "2017.x";
+
+    /**
+     * {@inheritDoc}
+     * @see AbstractWildFlySwarmInstalledLocalContainer#
+     * AbstractWildFlySwarmInstalledLocalContainer(LocalConfiguration)
+     * */
+    public WildFlySwarm2017xInstalledLocalContainer(LocalConfiguration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public String getId()
+    {
+        return CONTAINER_ID;
+    }
+
+    @Override
+    protected String getVersion()
+    {
+        return VERSION;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmFactoryRegistry.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmFactoryRegistry.java
@@ -1,0 +1,97 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.wildfly.swarm;
+
+import org.codehaus.cargo.container.ContainerType;
+import org.codehaus.cargo.container.configuration.ConfigurationType;
+import org.codehaus.cargo.container.wildfly.swarm.internal.WildFlySwarmContainerCapability;
+import org.codehaus.cargo.container.wildfly.swarm.internal.
+        WildFlySwarmStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.generic.AbstractFactoryRegistry;
+import org.codehaus.cargo.generic.ContainerCapabilityFactory;
+import org.codehaus.cargo.generic.ContainerFactory;
+import org.codehaus.cargo.generic.configuration.ConfigurationCapabilityFactory;
+import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
+import org.codehaus.cargo.generic.deployable.DeployableFactory;
+import org.codehaus.cargo.generic.deployer.DeployerFactory;
+import org.codehaus.cargo.generic.packager.PackagerFactory;
+
+/**
+ * Factory registry for WildFly Swarm containers.
+ * */
+public class WildFlySwarmFactoryRegistry extends AbstractFactoryRegistry
+{
+
+    @Override
+    protected void register(DeployableFactory factory)
+    {
+        //no deployments are supported
+    }
+
+    @Override
+    protected void register(ConfigurationCapabilityFactory factory)
+    {
+        factory.registerConfigurationCapability(
+                WildFlySwarm2017xInstalledLocalContainer.CONTAINER_ID,
+                ContainerType.INSTALLED,
+                ConfigurationType.STANDALONE,
+                WildFlySwarmStandaloneLocalConfigurationCapability.class);
+    }
+
+    @Override
+    protected void register(ConfigurationFactory factory)
+    {
+        factory.registerConfiguration(
+                WildFlySwarm2017xInstalledLocalContainer.CONTAINER_ID,
+                ContainerType.INSTALLED,
+                ConfigurationType.STANDALONE,
+                WildFlySwarmStandaloneLocalConfiguration.class
+        );
+    }
+
+    @Override
+    protected void register(DeployerFactory factory)
+    {
+        //no deployments are supported
+    }
+
+    @Override
+    protected void register(PackagerFactory factory)
+    {
+        //no packages are supported
+    }
+
+    @Override
+    protected void register(ContainerFactory factory)
+    {
+        factory.registerContainer(
+                WildFlySwarm2017xInstalledLocalContainer.CONTAINER_ID,
+                ContainerType.INSTALLED,
+                WildFlySwarm2017xInstalledLocalContainer.class);
+    }
+
+    @Override
+    protected void register(ContainerCapabilityFactory factory)
+    {
+        factory.registerContainerCapability(
+                WildFlySwarm2017xInstalledLocalContainer.CONTAINER_ID,
+                WildFlySwarmContainerCapability.class);
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmPropertySet.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmPropertySet.java
@@ -1,0 +1,37 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm;
+
+/**
+ * WildFly Swarm property set.
+ * */
+public interface WildFlySwarmPropertySet
+{
+    /**
+     * The project name used for a project descriptor file.
+     */
+    String SWARM_PROJECT_NAME = "cargo.swarm.project.name";
+
+    /**
+     * URL of an application deployed with WildFly Swarm.
+     * */
+    String SWARM_APPLICATION_URL = "cargo.swarm.ping.url";
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmStandaloneLocalConfiguration.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmStandaloneLocalConfiguration.java
@@ -1,0 +1,139 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm;
+
+import org.codehaus.cargo.container.LocalContainer;
+import org.codehaus.cargo.container.configuration.ConfigurationCapability;
+import org.codehaus.cargo.container.spi.configuration.AbstractStandaloneLocalConfiguration;
+import org.codehaus.cargo.container.wildfly.swarm.internal.
+        WildFlySwarmStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.ConfigurationContext;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.WildFlySwarmConfiguratorFactory;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.yaml.WildFlySwarmYamlConfiguratorFactory;
+
+import java.io.File;
+import java.io.Flushable;
+import java.io.IOException;
+
+/**
+ * WildFly Swarm standalone container configuration.
+ * */
+public class WildFlySwarmStandaloneLocalConfiguration extends AbstractStandaloneLocalConfiguration
+{
+
+    /**
+     * Default Swarm project name.
+     * */
+    private static final String DEFAULT_PROJECT_CONFIG_NAME = "cargo";
+
+    /**
+     * WildFly Swarm capability instance.
+     * */
+    private static final ConfigurationCapability CAPABILITY =
+            new WildFlySwarmStandaloneLocalConfigurationCapability();
+
+    /**
+     * Reference to a configurator factory.
+     * */
+    private final WildFlySwarmConfiguratorFactory configuratorFactory;
+
+    /**
+     * {@inheritDoc}
+     * @see AbstractStandaloneLocalConfiguration#AbstractStandaloneLocalConfiguration(String)
+     */
+    public WildFlySwarmStandaloneLocalConfiguration(String home)
+    {
+        super(home);
+        ConfigurationContext context = new ConfigurationContext(
+                getFileHandler(),
+                getHome(),
+                getSwarmProjectDescriptor()
+        );
+        this.configuratorFactory = new WildFlySwarmYamlConfiguratorFactory(context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ConfigurationCapability getCapability()
+    {
+        return CAPABILITY;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doConfigure(LocalContainer container) throws Exception
+    {
+        setupConfigurationDir();
+
+        configureUsers();
+        flush();
+    }
+
+    /**
+     * Resolves Swarm project descriptor file.
+     * @return Swarm project descriptor file.
+     * */
+    public File getSwarmProjectDescriptor()
+    {
+        String projectNameProperty = getPropertyValue(WildFlySwarmPropertySet.SWARM_PROJECT_NAME);
+        String projectName = projectNameProperty != null
+                ? projectNameProperty : DEFAULT_PROJECT_CONFIG_NAME;
+
+        return new File(getHome(), getSwarmProjectDescriptorName(projectName));
+    }
+
+    /**
+     * Constructs Swarm project descriptor file name.
+     * @param projectName Swarm project name.
+     * @return Swarm project descriptor file name.
+     * */
+    private String getSwarmProjectDescriptorName(String projectName)
+    {
+        return "project-" + projectName + ".yaml";
+    }
+
+    /**
+     * Configure user accounts.
+     * */
+    private void configureUsers()
+    {
+        configuratorFactory.userAccountsConfigurator().configureApplicationUsers(getUsers());
+    }
+
+    /**
+     * Flushes the configuration changes.
+     * */
+    private void flush()
+    {
+        try
+        {
+            ((Flushable) configuratorFactory).flush();
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/AbstractWildFlySwarmInstalledLocalContainer.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/AbstractWildFlySwarmInstalledLocalContainer.java
@@ -1,0 +1,196 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.wildfly.swarm.internal;
+
+import java.io.File;
+import org.codehaus.cargo.container.ContainerCapability;
+import org.codehaus.cargo.container.ContainerException;
+import org.codehaus.cargo.container.configuration.Configuration;
+import org.codehaus.cargo.container.configuration.LocalConfiguration;
+import org.codehaus.cargo.container.property.GeneralPropertySet;
+import org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncher;
+import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmPropertySet;
+import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmStandaloneLocalConfiguration;
+import org.codehaus.cargo.container.wildfly.swarm.internal.jvm.SwarmJvmLauncherFactory;
+
+/**
+ * WildFly Swarm container common implementation.
+ */
+public abstract class AbstractWildFlySwarmInstalledLocalContainer extends
+        AbstractInstalledLocalContainer
+{
+
+    /**
+     * Container capability instance.
+     */
+    private static final ContainerCapability CAPABILITY = new WildFlySwarmContainerCapability();
+
+    /**
+     * JVM launcher instance.
+     * */
+    private JvmLauncher swarmJvmLauncher;
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see AbstractInstalledLocalContainer#AbstractInstalledLocalContainer(LocalConfiguration)
+     */
+    protected AbstractWildFlySwarmInstalledLocalContainer(LocalConfiguration configuration)
+    {
+        super(configuration);
+        setJvmLauncherFactory(new SwarmJvmLauncherFactory());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName()
+    {
+        return "WildFly Swarm " + getVersion();
+    }
+
+    /**
+     * Container version.
+     *
+     * @return version string.
+     */
+    protected abstract String getVersion();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void verify()
+    {
+        if (getHome() == null)
+        {
+            throw new ContainerException("You must set the mandatory [home] property");
+        }
+
+        final File wildFlySwarmExecutable = new File(getHome());
+        if (!wildFlySwarmExecutable.exists() || !wildFlySwarmExecutable.getName().endsWith(".jar"))
+        {
+            throw new ContainerException("[" + getHome() + "] "
+                    + "does not point to a valid WildFly Swarm executable.");
+        }
+
+        verifyPingURL();
+    }
+
+    /**
+     * Verifies that the property {@link WildFlySwarmPropertySet#SWARM_APPLICATION_URL} has been
+     * defined.
+     * */
+    private void verifyPingURL()
+    {
+        String pingUrl =
+                getConfiguration().getPropertyValue(WildFlySwarmPropertySet.SWARM_APPLICATION_URL);
+
+        if (pingUrl == null || pingUrl.isEmpty())
+        {
+            throw new ContainerException("Missing mandatory configuration property ["
+                    + WildFlySwarmPropertySet.SWARM_APPLICATION_URL
+                    + "].");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContainerCapability getCapability()
+    {
+        return CAPABILITY;
+    }
+
+    @Override
+    protected void startInternal() throws Exception
+    {
+        swarmJvmLauncher = createJvmLauncher(true);
+        addMemoryArguments(swarmJvmLauncher);
+        doStart(swarmJvmLauncher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void stopInternal() throws Exception
+    {
+        doStop(swarmJvmLauncher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doStart(JvmLauncher java) throws Exception
+    {
+        final File swarmExecutable = new File(getHome());
+        swarmJvmLauncher.setJarFile(swarmExecutable);
+        swarmJvmLauncher.setWorkingDirectory(swarmExecutable.getParentFile());
+
+        final Configuration configuration = getConfiguration();
+
+        String jvmArgs = configuration.getPropertyValue(GeneralPropertySet.JVMARGS);
+        if (jvmArgs != null)
+        {
+            swarmJvmLauncher.addJvmArgumentLine(jvmArgs);
+        }
+
+        WildFlySwarmStandaloneLocalConfiguration wildFlySwarmConfiguration =
+                (WildFlySwarmStandaloneLocalConfiguration) configuration;
+        File swarmProjectDescriptor = wildFlySwarmConfiguration.getSwarmProjectDescriptor();
+        if (swarmProjectDescriptor != null && swarmProjectDescriptor.exists())
+        {
+            swarmJvmLauncher.addAppArgumentLine("-s "
+                    + swarmProjectDescriptor.getAbsolutePath());
+        }
+
+        swarmJvmLauncher.start();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doStop(JvmLauncher java) throws Exception
+    {
+        swarmJvmLauncher.kill();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void waitForCompletion(boolean waitForStarting) throws InterruptedException
+    {
+        if (waitForStarting)
+        {
+            waitForStarting(new WildFlySwarmStartupMonitor(this));
+        }
+        else
+        {
+            super.waitForCompletion(waitForStarting);
+        }
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmContainerCapability.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmContainerCapability.java
@@ -1,0 +1,41 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal;
+
+import org.codehaus.cargo.container.ContainerCapability;
+import org.codehaus.cargo.container.deployable.DeployableType;
+
+/**
+ * WildFly Swarm container capability.
+ * */
+public class WildFlySwarmContainerCapability implements ContainerCapability
+{
+    /**
+     * As WildFly Swarm is already bundled with application, it does not support any deployment.
+     * {@inheritDoc}
+     * @return always false.
+     * */
+    @Override
+    public boolean supportsDeployableType(DeployableType type)
+    {
+        return false;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStandaloneLocalConfigurationCapability.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStandaloneLocalConfigurationCapability.java
@@ -1,0 +1,41 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal;
+
+import org.codehaus.cargo.container.spi.configuration.
+        AbstractStandaloneLocalConfigurationCapability;
+import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmPropertySet;
+
+/**
+ * WildFly Swarm standalone local configuration capability.
+ * */
+public class WildFlySwarmStandaloneLocalConfigurationCapability extends
+        AbstractStandaloneLocalConfigurationCapability
+{
+    /**
+     * Accepts WildFly Swarm-specific properties.
+     * */
+    public WildFlySwarmStandaloneLocalConfigurationCapability()
+    {
+        this.propertySupportMap.put(WildFlySwarmPropertySet.SWARM_PROJECT_NAME, Boolean.TRUE);
+        this.propertySupportMap.put(WildFlySwarmPropertySet.SWARM_APPLICATION_URL, Boolean.TRUE);
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStartupMonitor.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStartupMonitor.java
@@ -1,0 +1,62 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.codehaus.cargo.container.Container;
+import org.codehaus.cargo.container.ContainerException;
+import org.codehaus.cargo.container.spi.startup.AbstractPingContainerMonitor;
+import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmPropertySet;
+
+/**
+ * Monitors URL that is provided as a mandatory configuration property. WildFly Swarm does not
+ * accept deployments - container is bundled together with application, thus defining the ping URL
+ * is user's responsibility.
+ * */
+public class WildFlySwarmStartupMonitor extends AbstractPingContainerMonitor
+{
+
+    /**
+     * {@inheritDoc}
+     * @see {@link AbstractPingContainerMonitor#AbstractPingContainerMonitor(Container)}
+     * */
+    public WildFlySwarmStartupMonitor(final Container container)
+    {
+        super(container);
+    }
+
+    @Override
+    protected URL getPingUrl()
+    {
+        String pingUrl =
+                getConfiguration().getPropertyValue(WildFlySwarmPropertySet.SWARM_APPLICATION_URL);
+        try
+        {
+            return new URL(pingUrl);
+        }
+        catch (MalformedURLException ex)
+        {
+            throw new ContainerException("The WildFly Swarm ping URL [" + pingUrl
+                    + "] is not a valid URL. ", ex);
+        }
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/AbstractConfigurator.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/AbstractConfigurator.java
@@ -1,0 +1,50 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration;
+
+/**
+ * Common base for configurator classes.
+ * */
+public abstract class AbstractConfigurator
+{
+    /**
+     * Configuration context - data and utilities passed to Configurators.
+     * */
+    private final ConfigurationContext configurationContext;
+
+    /**
+     * Constructor.
+     * @param configurationContext ConfigurationContext instance.
+     * */
+    protected AbstractConfigurator(ConfigurationContext configurationContext)
+    {
+        this.configurationContext = configurationContext;
+    }
+
+    /**
+     * Getter for Configuration context.
+     * @return ConfigurationContext instance.
+     * */
+    public ConfigurationContext getConfigurationContext()
+    {
+        return configurationContext;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/ConfigurationContext.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/ConfigurationContext.java
@@ -1,0 +1,86 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration;
+
+import org.codehaus.cargo.util.FileHandler;
+import java.io.File;
+
+/**
+ * Context passed to configurators.
+ * */
+public class ConfigurationContext
+{
+    /**
+     * File handler utility instance.
+     * */
+    private final FileHandler fileHandler;
+
+    /**
+     * Configuration home directory.
+     * */
+    private final String configurationHome;
+
+    /**
+     * WildFly Swarm project descriptor.
+     * */
+    private final File projectDescriptor;
+
+    /**
+     * Constructor.
+     * @param fileHandler FileHandler utility.
+     * @param configurationHome Configuration home directory.
+     * @param projectDescriptor Project descriptor file.
+     * */
+    public ConfigurationContext(FileHandler fileHandler, String configurationHome,
+                                File projectDescriptor)
+    {
+        this.fileHandler = fileHandler;
+        this.configurationHome = configurationHome;
+        this.projectDescriptor = projectDescriptor;
+    }
+
+    /**
+     * FileHandler getter.
+     * @return File Handler instance.
+     * */
+    public FileHandler getFileHandler()
+    {
+        return fileHandler;
+    }
+
+    /**
+     * Configuration home directory getter.
+     * @return Path to configuration home.
+     * */
+    public String getConfigurationHome()
+    {
+        return configurationHome;
+    }
+
+    /**
+     * Project descriptor getter.
+     * @return Project descriptor file.
+     * */
+    public File getProjectDescriptor()
+    {
+        return projectDescriptor;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/UserAccountsConfigurator.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/UserAccountsConfigurator.java
@@ -1,0 +1,37 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration;
+
+import org.codehaus.cargo.container.property.User;
+
+import java.util.List;
+
+/**
+ * User accounts configurator.
+ * */
+public interface UserAccountsConfigurator
+{
+    /**
+     * Configures user accounts and roles.
+     * @param users list of users with roles to create.
+     * */
+    void configureApplicationUsers(final List<User> users);
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/WildFlySwarmConfiguratorFactory.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/WildFlySwarmConfiguratorFactory.java
@@ -1,0 +1,34 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration;
+
+/**
+ * Configurator factory interface. Multiple implementations can provide different strategies
+ * for configuring WildFly Swarm.
+ * */
+public interface WildFlySwarmConfiguratorFactory
+{
+    /**
+     * Provides an implementation of user accounts configurator.
+     * @return user accounts configurator implementation.
+     * */
+    UserAccountsConfigurator userAccountsConfigurator();
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/util/WildFlySwarmUserUtils.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/util/WildFlySwarmUserUtils.java
@@ -1,0 +1,88 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration.util;
+
+import org.codehaus.cargo.container.property.User;
+import org.codehaus.cargo.util.CargoException;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Utility class providing informations about users.
+ */
+public final class WildFlySwarmUserUtils
+{
+
+    /**
+     * System-dependent line separator.
+     * */
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
+    /**
+     * Cannot instantiate this class.
+     */
+    private WildFlySwarmUserUtils()
+    {
+    }
+
+    /**
+     * Generate the user and password line for the JBoss users properties file.
+     * @param user User object.
+     * @param realm Real (for example, <code>ApplicationRealm</code>)
+     * @return User and password line for the WildFly Swarm users properties file.
+     */
+    public static String generateUserPasswordLine(User user, String realm)
+    {
+        MessageDigest md5;
+        try
+        {
+            md5 = MessageDigest.getInstance("md5");
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new CargoException(
+                "Cannot get the MD5 digest for generating the JBoss user properties files", e);
+        }
+
+        String toHash = user.getName() + ":" + realm + ":" + user.getPassword();
+        byte[] hash;
+        try
+        {
+            hash = md5.digest(toHash.getBytes("UTF-8"));
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            throw new CargoException("Cannot encode one line for the "
+                + "application-users.properties file", e);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(user.getName());
+        sb.append("=");
+        for (byte hashByte : hash)
+        {
+            sb.append(String.format("%02x", hashByte));
+        }
+        sb.append(NEW_LINE);
+        return sb.toString();
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/UserAccountsYamlConfigurator.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/UserAccountsYamlConfigurator.java
@@ -1,0 +1,213 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.codehaus.cargo.container.property.User;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.AbstractConfigurator;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.ConfigurationContext;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.UserAccountsConfigurator;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.util.WildFlySwarmUserUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * User accounts configurator writing configuration to yaml.
+ */
+public class UserAccountsYamlConfigurator extends AbstractConfigurator
+        implements UserAccountsConfigurator
+{
+    /**
+     * YAML generator instance.
+     */
+    private final YAMLGenerator yamlGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param configurationContext configuration context.
+     * @param yamlGenerator          yaml generator instance.
+     */
+    public UserAccountsYamlConfigurator(ConfigurationContext configurationContext,
+                                        YAMLGenerator yamlGenerator)
+    {
+        super(configurationContext);
+        this.yamlGenerator = yamlGenerator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configureApplicationUsers(final List<User> users)
+    {
+        if (!users.isEmpty())
+        {
+            File applicationUsers = createApplicationUsersProperties(users);
+            File applicationRoles = createApplicationRolesProperties(users);
+            configureApplicationRealm(applicationUsers, applicationRoles);
+        }
+    }
+
+    /**
+     * Creates the yaml configuration pointing to users and roles properties files.
+     * @param applicationUsers application users.
+     * @param applicationRoles application roles.
+     * */
+    private void configureApplicationRealm(File applicationUsers, File applicationRoles)
+    {
+        try
+        {
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeFieldName("swarm");
+
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeFieldName("management");
+
+
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeFieldName("security-realms");
+
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeFieldName("ApplicationRealm");
+
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeFieldName("local-authentication");
+
+            yamlGenerator.writeStartObject();
+            yamlGenerator.writeStringField("default-user", "local");
+            yamlGenerator.writeStringField("allowed-users", "local");
+            yamlGenerator.writeStringField("skip-group-loading", "true");
+            yamlGenerator.writeEndObject();
+
+            yamlAuthenticationConfig(applicationUsers);
+            yamlAuthorizationConfig(applicationRoles);
+
+
+            yamlGenerator.writeEndObject();
+            yamlGenerator.writeEndObject();
+
+            yamlGenerator.writeEndObject();
+            yamlGenerator.writeEndObject();
+            yamlGenerator.writeEndObject();
+
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException("Error writing YAML configuration.", ex);
+        }
+    }
+
+    /**
+     * Creates YAML configuration for properties authentication.
+     * @param applicationUsers application-users.properties file
+     * @throws IOException when writing YAML content fails.
+     * */
+    private void yamlAuthenticationConfig(File applicationUsers) throws IOException
+    {
+        yamlGenerator.writeFieldName("properties-authentication");
+
+        yamlGenerator.writeStartObject();
+        yamlGenerator.writeStringField("path", applicationUsers.getAbsolutePath());
+        yamlGenerator.writeStringField("plain-text", "false");
+        yamlGenerator.writeEndObject();
+    }
+
+    /**
+     * Creates YAML configuration for properties authorization.
+     * @param applicationRoles application-roles.properties file
+     * @throws IOException when writing YAML content fails.
+     * */
+    private void yamlAuthorizationConfig(File applicationRoles) throws IOException
+    {
+        yamlGenerator.writeFieldName("properties-authorization");
+
+        yamlGenerator.writeStartObject();
+        yamlGenerator.writeStringField("path", applicationRoles.getAbsolutePath());
+        yamlGenerator.writeEndObject();
+    }
+
+    /**
+     * Create application users file (application-users.properties).
+     * @param users list of users to create.
+     * @return application-users.properties file.
+     */
+    private File createApplicationUsersProperties(List<User> users)
+    {
+        StringBuilder usersToken = new StringBuilder(
+                "# WildFly Swarm application-users.properties file generated by CARGO\n");
+
+        for (User user : users)
+        {
+            usersToken.append(WildFlySwarmUserUtils.generateUserPasswordLine(
+                    user, "ApplicationRealm"));
+        }
+
+        ConfigurationContext context = getConfigurationContext();
+        File applicationUsers =
+                new File(context.getConfigurationHome(), "/application-users.properties");
+
+        context.getFileHandler().writeTextFile(
+                applicationUsers.getAbsolutePath(),
+                usersToken.toString(),
+                "UTF-8"
+        );
+
+        return applicationUsers;
+
+    }
+
+    /**
+     * Create application roles file (application-roles.properties).
+     * @param users list of users to create.
+     * @return application-roles.properties file.
+     */
+    private File createApplicationRolesProperties(List<User> users)
+    {
+        StringBuilder rolesToken = new StringBuilder(
+                "# WildFly Swarm application-roles.properties file generated by CARGO\n");
+
+        for (User user : users)
+        {
+            rolesToken.append(user.getName());
+            rolesToken.append("=");
+            for (String role : user.getRoles())
+            {
+                rolesToken.append(role);
+                rolesToken.append(",");
+            }
+            rolesToken.append('\n');
+        }
+
+        ConfigurationContext context = getConfigurationContext();
+        File applicationRoles =
+                new File(context.getConfigurationHome(), "/application-roles.properties");
+        context.getFileHandler().writeTextFile(
+                applicationRoles.getAbsolutePath(),
+                rolesToken.toString(),
+                "UTF-8"
+        );
+
+        return applicationRoles;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/WildFlySwarmYamlConfiguratorFactory.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/WildFlySwarmYamlConfiguratorFactory.java
@@ -1,0 +1,148 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.ConfigurationContext;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.UserAccountsConfigurator;
+import org.codehaus.cargo.container.wildfly.swarm.internal.configuration.WildFlySwarmConfiguratorFactory;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * WildFly Swarm yaml configuration factory. Writes configuration changes to project-{name}.yaml
+ * file.
+ * */
+public final class WildFlySwarmYamlConfiguratorFactory implements
+        WildFlySwarmConfiguratorFactory, Flushable
+{
+    /**
+     * Configuration context makes accessible data and utilities from configuration.
+     * */
+    private final ConfigurationContext configurationContext;
+
+    /**
+     * YAML generator instance for creating YAML content.
+     * */
+    private final YAMLGenerator yamlGenerator;
+
+    /**
+     * User accounts configuration implementation.
+     * */
+    private UserAccountsConfigurator userAccountsYamlConfigurator;
+
+
+    /**
+     * Creates new instance of this factory class.
+     * @param configurationContext configuration context.
+     * */
+    public WildFlySwarmYamlConfiguratorFactory(ConfigurationContext configurationContext)
+    {
+        this.configurationContext = configurationContext;
+        this.yamlGenerator = createYamlGenerator();
+    }
+
+    /**
+     * {@inheritDoc}
+     * */
+    @Override
+    public UserAccountsConfigurator userAccountsConfigurator()
+    {
+        if (userAccountsYamlConfigurator == null)
+        {
+            userAccountsYamlConfigurator =
+                    new UserAccountsYamlConfigurator(configurationContext, yamlGenerator);
+        }
+        return userAccountsYamlConfigurator;
+    }
+
+    /**
+     * {@inheritDoc}
+     * */
+    @Override
+    public void flush()
+    {
+        boolean isEmpty = false;
+        try
+        {
+            yamlGenerator.flush();
+            String yamlContent = yamlGenerator.getOutputTarget().toString();
+
+            if (yamlContent != null && !yamlContent.isEmpty())
+            {
+                configurationContext.getFileHandler().writeTextFile(
+                        configurationContext.getProjectDescriptor().getAbsolutePath(),
+                        yamlContent,
+                        "UTF-8"
+                );
+            }
+            else
+            {
+                isEmpty = true;
+            }
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException("Unable to flush YAML generator.", ex);
+        }
+        finally
+        {
+            if (!isEmpty)
+            {
+                try
+                {
+                    yamlGenerator.close();
+                }
+                catch (IOException ex)
+                {
+                    throw new RuntimeException("Unable to close YAML generator.", ex);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Creates YAML generator instance.
+     * @return YAMLGenerator instance.
+     * */
+    private YAMLGenerator createYamlGenerator()
+    {
+        final Writer writer = new StringWriter();
+
+        YAMLFactory yamlFactory = new YAMLFactory();
+        yamlFactory.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+        yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+
+        try
+        {
+            return yamlFactory.createGenerator(writer);
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException("Cannot create YAML generator.", ex);
+        }
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/StackTraceUtil.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/StackTraceUtil.java
@@ -1,0 +1,69 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.jvm;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * Utility class for Exceptions.
+ * */
+public final class StackTraceUtil
+{
+    /**
+     * Prevent creating an instance.
+     * */
+    private StackTraceUtil()
+    {
+        // no instance
+    }
+
+    /**
+     * Returns error stacktrace as a String.
+     * @param error error to be converted to String.
+     * @return error stacktrace
+     * */
+    public static String getStackTrace(final Throwable error)
+    {
+        StringWriter writer = new StringWriter();
+
+        for (StackTraceElement element : error.getStackTrace())
+        {
+            writer.write(element.toString());
+        }
+
+        try
+        {
+            return writer.toString();
+        }
+        finally
+        {
+            try
+            {
+                writer.close();
+            }
+            catch (IOException ex)
+            {
+                //nothing to do here.
+            }
+        }
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/StreamRedirector.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/StreamRedirector.java
@@ -1,0 +1,114 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+package org.codehaus.cargo.container.wildfly.swarm.internal.jvm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Redirects the output of a process into an OutputStream by periodically pumping data.
+ *
+ */
+class StreamRedirector implements Runnable
+{
+    /**
+     * The size of the buffer that will contain the output data of the process.
+     */
+    private static final int BUFFERSIZE = 4096;
+
+    /**
+     * The input stream of the process
+     */
+    private final InputStream inputStream;
+
+    /**
+     * The output stream to redirect to.
+     */
+    private final OutputStream outputStream;
+
+    /**
+     * Exception that might occur in redirecting the stream.
+     * */
+    private Exception error;
+
+    /**
+     * Creates a new redirector.
+     *
+     * @param is the input stream
+     * @param os the output stream
+     */
+    public StreamRedirector(InputStream is, OutputStream os)
+    {
+        inputStream = is;
+        outputStream = os;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void run()
+    {
+        final byte[] buf = new byte[BUFFERSIZE];
+
+        int length;
+        try
+        {
+            while ((length = inputStream.read(buf)) > 0)
+            {
+                outputStream.write(buf, 0, length);
+            }
+            outputStream.flush();
+        }
+        catch (Exception e)
+        {
+            this.error = e;
+            return;
+        }
+    }
+
+    /**
+     * Closes the associated input stream.
+     * @throws IOException when input stream cannot be closed.
+     * */
+    public void close() throws IOException
+    {
+        inputStream.close();
+    }
+
+    /**
+     * Getter for error.
+     * @return error instance if any exception occured; null otherwise.
+     * */
+    public Exception getError()
+    {
+        return error;
+    }
+
+    /**
+     * Tells whether any error occurred.
+     * @return true in case error occurred, false otherwise.
+     * */
+    public boolean hasError()
+    {
+        return getError() != null;
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/SwarmJvmLauncher.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/SwarmJvmLauncher.java
@@ -1,0 +1,575 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.jvm;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.tools.ant.types.Commandline;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncher;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncherException;
+import org.codehaus.cargo.util.log.Logger;
+
+/**
+ * Custom launcher for WildFly Swarm. Swarm cannot guarantee there will be any management interface
+ * accepting commands (e.g. stop command), thus this implementation relies on
+ * {@link java.lang.Process}.
+ * */
+public class SwarmJvmLauncher implements JvmLauncher
+{
+
+    /**
+     * The working directory.
+     */
+    private File workingDirectory;
+
+    /**
+     * The executable to run.
+     */
+    private String executable;
+
+    /**
+     * The vm arguments.
+     */
+    private final List<String> jvmArguments = new ArrayList<String>();
+
+    /**
+     * The vm classpath.
+     */
+    private String classpath;
+
+    /**
+     * The vm jar path.
+     */
+    private String jarPath;
+
+    /**
+     * The main class to run.
+     */
+    private String mainClass;
+
+    /**
+     * The vm system properties.
+     */
+    private final List<String> systemProperties = new ArrayList<String>();
+
+    /**
+     * The extra environment variables.
+     */
+    private final Map<String, String> environmentVariables = new HashMap<String, String>();
+
+    /**
+     * The application arguments.
+     */
+    private final List<String> applicationArguments = new ArrayList<String>();
+
+    /**
+     * The running process.
+     */
+    private Process process;
+
+    /**
+     * Output file.
+     */
+    private File outputFile;
+
+    /**
+     * Append output.
+     */
+    private boolean appendOutput = false;
+
+    /**
+     * Logger instance.
+     * */
+    private Logger logger;
+
+    /**
+     * Stream redirector.
+     * */
+    private StreamRedirector streamRedirector;
+
+    /**
+     * Sets to <code>true</code> when either {@link #kill()} has been called or a shutdown hook
+     * took effect.
+     * */
+    private AtomicBoolean killed = new AtomicBoolean(false);
+
+    /**
+     * Constructor.
+     * @param logger logger instance.
+     * */
+    public SwarmJvmLauncher(final Logger logger)
+    {
+        this.logger = logger;
+    }
+
+    /**
+     * Build the complete command line.
+     *
+     * @return the array representing the tokens of the command line
+     */
+    private List<String> buildCommandLine()
+    {
+        List<String> commandLine = new ArrayList<String>();
+
+        commandLine.add(executable);
+
+        commandLine.addAll(jvmArguments);
+        commandLine.addAll(systemProperties);
+
+        if (classpath != null && jarPath == null)
+        {
+            commandLine.add("-classpath");
+            commandLine.add(classpath);
+        }
+
+        if (jarPath != null)
+        {
+            commandLine.add("-jar");
+            commandLine.add(jarPath);
+        }
+
+        if (jarPath == null)
+        {
+            commandLine.add(mainClass);
+        }
+        commandLine.addAll(applicationArguments);
+
+        return commandLine;
+    }
+
+    /**
+     * Add a path to the classpath.
+     *
+     * @param path the path to add to the classpath
+     */
+    private void addClasspath(String path)
+    {
+        if (classpath == null)
+        {
+            classpath = path;
+        }
+        else
+        {
+            classpath += File.pathSeparator + path;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setWorkingDirectory(File workingDirectory)
+    {
+        this.workingDirectory = workingDirectory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setJvm(String command)
+    {
+        if (command == null || command.isEmpty())
+        {
+            return;
+        }
+        this.executable =
+                command.replace('/', File.separatorChar).replace('\\', File.separatorChar);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addJvmArgument(File file)
+    {
+        if (file != null)
+        {
+            jvmArguments.add(file.getAbsolutePath());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addJvmArguments(String... values)
+    {
+        if (values != null)
+        {
+            for (String value : values)
+            {
+                jvmArguments.add(value);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addJvmArgumentLine(String line)
+    {
+        if (line != null)
+        {
+            String[] args = Commandline.translateCommandline(line);
+
+            if (args != null)
+            {
+                for (String arg : args)
+                {
+                    jvmArguments.add(arg);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addClasspathEntries(String... paths)
+    {
+        if (paths != null)
+        {
+            for (String path : paths)
+            {
+                addClasspath(path);
+            }
+        }
+    }
+
+    /**
+     * Adds additional classpath entries.
+     *
+     * @param paths The additional classpath entries.
+     */
+    public void addClasspathEntries(List<String> paths)
+    {
+        if (paths != null)
+        {
+            for (String path : paths)
+            {
+                addClasspath(path);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addClasspathEntries(File... paths)
+    {
+        if (paths != null)
+        {
+            for (File path : paths)
+            {
+                addClasspath(path.getAbsolutePath());
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getClasspath()
+    {
+        return classpath;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSystemProperty(String name, String value)
+    {
+        if (name != null && !name.isEmpty())
+        {
+            systemProperties.add("-D" + name + "=" + value);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnvironmentVariable(String name, String value)
+    {
+        if (name != null && !name.isEmpty())
+        {
+            environmentVariables.put(name, value);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEnvironmentVariable(String name)
+    {
+        String value = environmentVariables.get(name);
+        if (value == null)
+        {
+            value = System.getenv(name);
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setJarFile(File jarFile)
+    {
+        if (jarFile != null)
+        {
+            jarPath = jarFile.getAbsolutePath();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMainClass(String mainClass)
+    {
+        if (mainClass != null)
+        {
+            this.mainClass = mainClass;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAppArgument(File file)
+    {
+        if (file != null)
+        {
+            applicationArguments.add(file.getAbsolutePath());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAppArguments(String... values)
+    {
+        if (values != null)
+        {
+            for (String value : values)
+            {
+                applicationArguments.add(value);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addAppArgumentLine(String line)
+    {
+        if (line != null)
+        {
+            String[] args = Commandline.translateCommandline(line);
+
+            if (args != null)
+            {
+                for (String arg : args)
+                {
+                    applicationArguments.add(arg);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setOutputFile(File outputFile)
+    {
+        this.outputFile = outputFile;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setAppendOutput(boolean appendOutput)
+    {
+        this.appendOutput = appendOutput;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getCommandLine()
+    {
+        StringBuilder result = new StringBuilder();
+        List<String> commandLine = buildCommandLine();
+        if (commandLine != null)
+        {
+            for (int i = 0; i < commandLine.size(); i++)
+            {
+                if (i != 0)
+                {
+                    result.append(' ');
+                }
+
+                result.append(commandLine.get(i));
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void kill()
+    {
+        terminateProcess();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTimeout(long millis)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSpawn(boolean spawn)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() throws JvmLauncherException
+    {
+        try
+        {
+            ProcessBuilder pb =
+                    new ProcessBuilder(buildCommandLine()).directory(workingDirectory)
+                            .redirectErrorStream(true);
+            pb.environment().putAll(environmentVariables);
+
+            this.process = pb.start();
+
+            OutputStream out = System.out;
+            if (outputFile != null)
+            {
+                out = new FileOutputStream(outputFile, appendOutput);
+            }
+
+            this.streamRedirector = new StreamRedirector(process.getInputStream(), out);
+
+            new Thread(streamRedirector).start();
+        }
+        catch (IOException e)
+        {
+            throw new JvmLauncherException("Failed to launch process " + e);
+        }
+        finally
+        {
+            Runtime.getRuntime().addShutdownHook(new Thread()
+            {
+                @Override
+                public void run()
+                {
+                    SwarmJvmLauncher.this.terminateProcess();
+                }
+            });
+        }
+    }
+
+    /**
+     * Terminates Swarm process execution.
+     * */
+    private void terminateProcess()
+    {
+        if (!killed.getAndSet(true))
+        {
+            process.destroy();
+
+            if (streamRedirector != null)
+            {
+                if (streamRedirector.hasError())
+                {
+                    String message =
+                            StackTraceUtil.getStackTrace(streamRedirector.getError());
+                    logger.warn(message, SwarmJvmLauncher.class.getCanonicalName());
+                }
+
+                try
+                {
+                    streamRedirector.close();
+                }
+                catch (IOException e)
+                {
+                    logger.warn(
+                            StackTraceUtil.getStackTrace(e),
+                            SwarmJvmLauncher.class.getCanonicalName()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int execute() throws JvmLauncherException
+    {
+        start();
+        try
+        {
+            return this.process.waitFor();
+        }
+        catch (InterruptedException e)
+        {
+            throw new JvmLauncherException("Failed waiting for process to end", e);
+        }
+    }
+
+}

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/SwarmJvmLauncherFactory.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/jvm/SwarmJvmLauncherFactory.java
@@ -1,0 +1,42 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.jvm;
+
+import org.codehaus.cargo.container.spi.jvm.JvmLauncher;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncherFactory;
+import org.codehaus.cargo.container.spi.jvm.JvmLauncherRequest;
+
+/**
+ * Factory for a custom WildFly Swarm JVM launcher.
+ * */
+public class SwarmJvmLauncherFactory implements JvmLauncherFactory
+{
+    /**
+     * Creates a new @see {@link SwarmJvmLauncher} and sets logger.
+     * {@inheritDoc}
+     * @return Swarm JVM launcher instance.
+     * */
+    @Override
+    public JvmLauncher createJvmLauncher(final JvmLauncherRequest request)
+    {
+        return new SwarmJvmLauncher(request.getLoggable().getLogger());
+    }
+}

--- a/core/containers/wildfly-swarm/src/main/resources/META-INF/services/org.codehaus.cargo.generic.AbstractFactoryRegistry
+++ b/core/containers/wildfly-swarm/src/main/resources/META-INF/services/org.codehaus.cargo.generic.AbstractFactoryRegistry
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------
+# Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -------------------------------------------------------------------
+
+org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmFactoryRegistry

--- a/core/containers/wildfly-swarm/src/test/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/YamlGeneratorTest.java
+++ b/core/containers/wildfly-swarm/src/test/java/org/codehaus/cargo/container/wildfly/swarm/internal/configuration/yaml/YamlGeneratorTest.java
@@ -1,0 +1,150 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.container.wildfly.swarm.internal.configuration.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * Tests YAML creation used by WildFly Swarm configurator classes.
+ * */
+public class YamlGeneratorTest extends TestCase
+{
+    /**
+     * Factory for creating {@link YAMLGenerator} instances.
+     * */
+    private final YAMLFactory yamlFactory = new YAMLFactory();
+
+    /**
+     * YAML generator under test.
+     * */
+    private YAMLGenerator yamlGenerator;
+
+    /**
+     * Prepares test environment - creates a new YAML generator.
+     * */
+    public void setUp()
+    {
+        this.yamlGenerator = createYamlGenerator();
+    }
+
+    /**
+     * Closes the YAML generator used in tests.
+     * */
+    public void tearDown()
+    {
+        closeGenerator();
+    }
+
+    /**
+     * Tests a simple {@link YAMLGenerator} usage.
+     * @throws IOException if creating YAML content fails.
+     * */
+    public void testSimpleYamlGeneration() throws IOException
+    {
+        Assert.assertFalse(yamlFactory.isEnabled(YAMLGenerator.Feature.WRITE_DOC_START_MARKER));
+        Assert.assertTrue(yamlFactory.isEnabled(YAMLGenerator.Feature.MINIMIZE_QUOTES));
+
+        yamlGenerator.writeStartObject();
+        yamlGenerator.writeFieldName("swarm");
+        yamlGenerator.writeStartObject();
+        yamlGenerator.writeStringField("management", "true");
+        yamlGenerator.writeEndObject();
+        yamlGenerator.writeEndObject();
+
+        final String result = getYamlString();
+
+        Assert.assertEquals("swarm:\n  management: true", result);
+    }
+
+    /**
+     * Converts YAML generator's content to string.
+     * @return YAML string.
+     * */
+    private String getYamlString()
+    {
+        try
+        {
+            yamlGenerator.flush();
+            String result = yamlGenerator.getOutputTarget().toString();
+            return result;
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException(ex);
+        }
+        finally
+        {
+            try
+            {
+                yamlGenerator.close();
+            }
+            catch (IOException ex)
+            {
+                throw new RuntimeException(ex);
+            }
+        }
+
+    }
+
+    /**
+     * Closes the YAML generator.
+     * */
+    private void closeGenerator()
+    {
+        if (yamlGenerator != null)
+        {
+            try
+            {
+                yamlGenerator.close();
+            }
+            catch (IOException ex)
+            {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    /**
+     * Creates a new generator.
+     * @return YAMLGenerator instance.
+     * */
+    private YAMLGenerator createYamlGenerator()
+    {
+        final Writer writer = new StringWriter();
+        yamlFactory.configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+        yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        try
+        {
+            return yamlFactory.createGenerator(writer);
+        }
+        catch (IOException ex)
+        {
+            throw new RuntimeException("Cannot create YAML generator.", ex);
+        }
+    }
+}

--- a/extensions/maven2/samples/pom.xml
+++ b/extensions/maven2/samples/pom.xml
@@ -54,6 +54,7 @@
     <module>users-test</module>
     <module>weblogic-test</module>
     <module>websphere-test</module>
+    <module>wildfly-swarm-test</module>
   </modules>
 
   <build>

--- a/extensions/maven2/samples/wildfly-swarm-test/pom.xml
+++ b/extensions/maven2/samples/wildfly-swarm-test/pom.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ ========================================================================
+  ~
+  ~  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  ~  ========================================================================
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cargo-samples-maven2</artifactId>
+    <groupId>org.codehaus.cargo</groupId>
+    <version>1.6.5-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>wildfly-swarm-test</artifactId>
+
+  <packaging>war</packaging>
+
+  <properties>
+    <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+    <cargo.samples.servlet.port>8080</cargo.samples.servlet.port>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>bom-all</artifactId>
+        <version>${version.wildfly-swarm}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.spec.javax.servlet</groupId>
+        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+        <version>1.0.0.Final</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-api-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-sample-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>wildfly-swarm</id>
+      <activation>
+        <!-- WildFly Swarm works on JDK 8+ only. -->
+        <jdk>[1.8,)</jdk>
+        <property>
+          <name>cargo.wildfly-swarm2017x.home</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <includes>
+                  <include>**/*IT.java</include>
+                </includes>
+                <systemPropertyVariables>
+                  <http.port>${cargo.samples.servlet.port}</http.port>
+                </systemPropertyVariables>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>verify</id>
+                  <goals>
+                    <goal>verify</goal>
+                  </goals>
+                  <phase>verify</phase>
+                </execution>
+                <execution>
+                  <id>run-integration-tests</id>
+                  <goals>
+                    <goal>integration-test</goal>
+                  </goals>
+                  <phase>integration-test</phase>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.wildfly.swarm</groupId>
+              <artifactId>wildfly-swarm-plugin</artifactId>
+              <version>${version.wildfly-swarm}</version>
+              <configuration>
+                <jvmArguments>
+                  <jvmArgument>-Xmx128m</jvmArgument>
+                </jvmArguments>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>package</id>
+                  <goals>
+                    <goal>package</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <version>${project.version}</version>
+              <configuration>
+                <container>
+                  <containerId>wildfly-swarm2017x</containerId>
+                  <type>installed</type>
+                  <home>${cargo.wildfly-swarm2017x.home}</home>
+                  <systemProperties>
+                    <org.test.property>testValue</org.test.property>
+                  </systemProperties>
+                </container>
+                <configuration>
+                  <type>standalone</type>
+                  <properties>
+                    <cargo.swarm.ping.url>http://localhost:8080/test</cargo.swarm.ping.url>
+                    <cargo.servlet.port>${cargo.samples.servlet.port}</cargo.servlet.port>
+                    <cargo.swarm.project.name>testing</cargo.swarm.project.name>
+                  </properties>
+                </configuration>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>start</id>
+                  <phase>pre-integration-test</phase>
+                  <goals>
+                    <goal>start</goal>
+                  </goals>
+                </execution>
+                <execution>
+                  <id>stop</id>
+                  <phase>post-integration-test</phase>
+                  <goals>
+                    <goal>stop</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven2-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/extensions/maven2/samples/wildfly-swarm-test/src/main/java/org/codehaus/cargo/sample/maven2/wildfly/swarm/TestServlet.java
+++ b/extensions/maven2/samples/wildfly-swarm-test/src/main/java/org/codehaus/cargo/sample/maven2/wildfly/swarm/TestServlet.java
@@ -1,0 +1,44 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.sample.maven2.wildfly.swarm;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Testing servlet.
+ * */
+@WebServlet("/*")
+public class TestServlet extends HttpServlet
+{
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws
+            ServletException, IOException
+    {
+        resp.getWriter().write("Test successful, property value:"
+                + System.getProperty("org.test.property"));
+        resp.getWriter().close();
+    }
+}

--- a/extensions/maven2/samples/wildfly-swarm-test/src/test/java/org/codehaus/cargo/sample/maven2/wildfly/swarm/WildFlySwarmIT.java
+++ b/extensions/maven2/samples/wildfly-swarm-test/src/test/java/org/codehaus/cargo/sample/maven2/wildfly/swarm/WildFlySwarmIT.java
@@ -1,0 +1,52 @@
+/*
+ * ========================================================================
+ *
+ *  Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2017 Ali Tokmen.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  ========================================================================
+ */
+
+package org.codehaus.cargo.sample.maven2.wildfly.swarm;
+
+import junit.framework.TestCase;
+
+import org.codehaus.cargo.sample.java.PingUtils;
+import org.codehaus.cargo.util.log.Logger;
+import org.codehaus.cargo.util.log.SimpleLogger;
+
+import java.net.URL;
+
+/**
+ * Simple WildFly Swarm integration test.
+ * */
+public class WildFlySwarmIT extends TestCase
+{
+    /**
+     * Logger.
+     */
+    private Logger logger = new SimpleLogger();
+
+    /**
+     * Test WildFly Swarm is running and test servlet responds.
+     * @throws Exception If anything fails.
+     */
+    public void testSimpleServlet() throws Exception
+    {
+        final URL url = new URL("http://localhost:" + System.getProperty("http.port"));
+        final String expected = "Test successful, property value:testValue";
+
+        PingUtils.assertPingTrue(url.getPath() + " not started", expected, url, logger);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -671,6 +671,11 @@
       <!-- External dependencies -->
       <!-- Sorted alphabetically by groupId (and artifactId + type if needed). Keep the order! -->
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>2.7.9</version>
+      </dependency>
+      <dependency>
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>1.1.1</version>


### PR DESCRIPTION
Adds support for WildFly Swarm in a new module in core/containers. 
As the container and application are bundled together, this container does not support any deployment. 
Configuration is done via YAML project descriptor passed as an argument when running the swarm uberjar. 
New JVM launcher inspired by DaemonJvmLauncher is required as WildFly Swarm, in contrast to WildFly, cannot rely on management interface, as it's availability depends on user's configuration.