### PR TITLE
Introduce Hollow Swarm mode for WildFly Swarm

### DIFF
--- a/core/containers/wildfly-swarm/pom.xml
+++ b/core/containers/wildfly-swarm/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-container-jboss</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmFactoryRegistry.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmFactoryRegistry.java
@@ -21,6 +21,8 @@ package org.codehaus.cargo.container.wildfly.swarm;
 
 import org.codehaus.cargo.container.ContainerType;
 import org.codehaus.cargo.container.configuration.ConfigurationType;
+import org.codehaus.cargo.container.deployable.DeployableType;
+import org.codehaus.cargo.container.jboss.deployable.JBossWAR;
 import org.codehaus.cargo.container.wildfly.swarm.internal.WildFlySwarmContainerCapability;
 import org.codehaus.cargo.container.wildfly.swarm.internal.WildFlySwarmStandaloneLocalConfigurationCapability;
 import org.codehaus.cargo.generic.AbstractFactoryRegistry;
@@ -45,6 +47,9 @@ public class WildFlySwarmFactoryRegistry extends AbstractFactoryRegistry
     protected void register(DeployableFactory factory)
     {
         //no deployments are supported
+        factory.registerDeployable(WildFlySwarm2017xInstalledLocalContainer.CONTAINER_ID,
+                DeployableType.WAR,
+                JBossWAR.class);
     }
 
     /**

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmPropertySet.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/WildFlySwarmPropertySet.java
@@ -33,4 +33,10 @@ public interface WildFlySwarmPropertySet
      * URL of an application deployed with WildFly Swarm.
      */
     String SWARM_APPLICATION_URL = "cargo.swarm.ping.url";
+
+    /**
+     * Property telling if Hollow Swarm mode is enabled. In this mode WildFly Swarm allows
+     * deployments.
+     */
+    String SWARM_HOLLOW_ENABLED = "cargo.swarm.hollowswarm";
 }

--- a/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStandaloneLocalConfigurationCapability.java
+++ b/core/containers/wildfly-swarm/src/main/java/org/codehaus/cargo/container/wildfly/swarm/internal/WildFlySwarmStandaloneLocalConfigurationCapability.java
@@ -36,5 +36,6 @@ public class WildFlySwarmStandaloneLocalConfigurationCapability extends
     {
         this.propertySupportMap.put(WildFlySwarmPropertySet.SWARM_PROJECT_NAME, Boolean.TRUE);
         this.propertySupportMap.put(WildFlySwarmPropertySet.SWARM_APPLICATION_URL, Boolean.TRUE);
+        this.propertySupportMap.put(WildFlySwarmPropertySet.SWARM_HOLLOW_ENABLED, Boolean.TRUE);
     }
 }

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/AbstractCargoTestCase.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/AbstractCargoTestCase.java
@@ -40,6 +40,7 @@ import org.codehaus.cargo.container.installer.ZipURLInstaller;
 import org.codehaus.cargo.container.property.GeneralPropertySet;
 import org.codehaus.cargo.container.property.LoggingLevel;
 import org.codehaus.cargo.container.property.ServletPropertySet;
+import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmPropertySet;
 import org.codehaus.cargo.generic.ContainerFactory;
 import org.codehaus.cargo.generic.DefaultContainerFactory;
 import org.codehaus.cargo.generic.configuration.ConfigurationFactory;
@@ -253,6 +254,12 @@ public abstract class AbstractCargoTestCase extends TestCase
         configuration.setProperty(GeneralPropertySet.LOGGING, LoggingLevel.HIGH.getLevel());
 
         configuration.setLogger(getLogger());
+
+        // WildFly Swarm can operate without deployment in Hollow Swarm mode
+        if (getTestData().containerId.startsWith("wildfly-swarm"))
+        {
+            configuration.setProperty(WildFlySwarmPropertySet.SWARM_HOLLOW_ENABLED, "true");
+        }
 
         return configuration;
     }

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/AllLocalContainerTest.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/AllLocalContainerTest.java
@@ -19,22 +19,15 @@
  */
 package org.codehaus.cargo.sample.java;
 
-import java.io.File;
-
 import junit.framework.Test;
 
 import org.codehaus.cargo.container.ContainerException;
 import org.codehaus.cargo.container.ContainerType;
 import org.codehaus.cargo.container.State;
 import org.codehaus.cargo.container.configuration.ConfigurationType;
-import org.codehaus.cargo.container.internal.util.ResourceUtils;
-import org.codehaus.cargo.container.property.GeneralPropertySet;
-import org.codehaus.cargo.container.spi.configuration.AbstractLocalConfiguration;
-import org.codehaus.cargo.container.wildfly.swarm.WildFlySwarmPropertySet;
 import org.codehaus.cargo.sample.java.validator.HasStandaloneConfigurationValidator;
 import org.codehaus.cargo.sample.java.validator.IsLocalContainerValidator;
 import org.codehaus.cargo.sample.java.validator.Validator;
-import org.codehaus.cargo.util.DefaultFileHandler;
 
 /**
  * Test for local containers.
@@ -75,21 +68,6 @@ public class AllLocalContainerTest extends AbstractCargoTestCase
     {
         setContainer(createContainer(createConfiguration(ConfigurationType.STANDALONE)));
 
-        if (getTestData().containerId.startsWith("wildfly-swarm"))
-        {
-            String cargocpc = new File(
-                new File(getInstalledLocalContainer().getHome()).getParentFile(),
-                    "cargocpc.war").getAbsolutePath();
-            new ResourceUtils().copyResource(
-                AbstractLocalConfiguration.RESOURCE_PATH + "cargocpc.war", cargocpc,
-                    new DefaultFileHandler());
-            getLocalContainer().getConfiguration().setProperty(GeneralPropertySet.RUNTIME_ARGS,
-                cargocpc);
-            getLocalContainer().getConfiguration().setProperty(
-                WildFlySwarmPropertySet.SWARM_APPLICATION_URL,
-                    "http://localhost:" + getTestData().port + "/favicon.ico");
-        }
-
         getLocalContainer().start();
         assertEquals(State.STARTED, getContainer().getState());
 
@@ -123,12 +101,6 @@ public class AllLocalContainerTest extends AbstractCargoTestCase
 
         // JOnAS 4.x has trouble restarting too quickly, skip
         if ("jonas4x".equals(getTestData().containerId))
-        {
-            return;
-        }
-
-        // WildFly Swarm is a headache to test, skip
-        if (getTestData().containerId.startsWith("wildfly-swarm"))
         {
             return;
         }

--- a/core/samples/pom.xml
+++ b/core/samples/pom.xml
@@ -1949,6 +1949,12 @@
       <properties>
         <cargo.containers>wildfly-swarm2017x</cargo.containers>
       </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.codehaus.cargo</groupId>
+          <artifactId>cargo-core-container-wildfly-swarm</artifactId>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>
@@ -1956,6 +1962,7 @@
             <artifactId>maven-dependency-plugin</artifactId>
             <executions>
               <execution>
+                <id>copy-hollowswarm-jar</id>
                 <phase>process-test-resources</phase>
                 <configuration>
                   <artifactItems>


### PR DESCRIPTION
Introducing Hollow Swarm mode as discussed in https://github.com/codehaus-cargo/cargo/pull/94.
- deployments can be added before WildFly Swarm starts
- AllLocalContainerTest is now passing

Tests with deployments are still not working (if e.g. WAR archive is enabled in ContainerCapability); will require further test refactoring. E.g. application context URL is by default root context for swarm, which needs to be changed by placing jboss-deployment-structure.xml descriptor into each test application to make passing.

Feel free to leave this PR open if you want to have the deployment tests addressed as a part of it.