### PR TITLE
CARGO-1457 Support parsing Java 10 version in JdkUtils

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/JdkUtils.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/JdkUtils.java
@@ -135,6 +135,11 @@ public final class JdkUtils
         {
             jvmVersion = jvmVersion.substring(0, separator);
         }
+        separator = jvmVersion.indexOf(' ');
+        if (separator > 0)
+        {
+            jvmVersion = jvmVersion.substring(0, separator);
+        }
         return Integer.parseInt(jvmVersion);
     }
 

--- a/core/api/container/src/test/java/org/codehaus/cargo/container/internal/util/JdkUtilsTest.java
+++ b/core/api/container/src/test/java/org/codehaus/cargo/container/internal/util/JdkUtilsTest.java
@@ -16,6 +16,7 @@ public class JdkUtilsTest extends TestCase
         assertEquals(7, JdkUtils.parseMajorJavaVersion("1.7.0_3"));
         assertEquals(8, JdkUtils.parseMajorJavaVersion("1.8.0_121"));
         assertEquals(9, JdkUtils.parseMajorJavaVersion("\"9-ea\""));
+        assertEquals(10, JdkUtils.parseMajorJavaVersion("\"10\" 2018-03-20"));
         assertTrue(JdkUtils.getMajorJavaVersion() > 0);
     }
 }


### PR DESCRIPTION
Supports parsing when AbstractInstalledLocalContainer.createJvmLauncher()
tries to parse the following "java -version" output:

```
java version "10" 2018-03-20
Java(TM) SE Runtime Environment 18.3 (build 10+46)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10+46, mixed mode)

```
Fixes:

```
Caused by: java.lang.NumberFormatException: For input string: "10 2018"
        at org.codehaus.cargo.container.internal.util.JdkUtils.parseMajorJavaVersion(JdkUtils.java:138)
        at org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer.createJvmLauncher(AbstractInstalledLocalContainer.java:399)
        at org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer.startInternal(AbstractInstalledLocalContainer.java:287)
        at org.codehaus.cargo.container.spi.AbstractLocalContainer.start(AbstractLocalContainer.java:226)
```