### PR TITLE
Add support for Tomcat's maxHttpHeaderSize setting

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat5xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat5xStandaloneLocalConfiguration.java
@@ -456,5 +456,12 @@ public class Tomcat5xStandaloneLocalConfiguration extends
             addXmlReplacement("conf/server.xml", CONNECTOR_XPATH, "sslProtocol",
                     TomcatPropertySet.CONNECTOR_SSL_PROTOCOL);
         }
+
+        if (container.getConfiguration().getPropertyValue(
+                TomcatPropertySet.CONNECTOR_MAX_HTTP_HEADER_SIZE) != null)
+        {
+            addXmlReplacement("conf/server.xml", CONNECTOR_XPATH, "maxHttpHeaderSize",
+                    TomcatPropertySet.CONNECTOR_MAX_HTTP_HEADER_SIZE);
+        }
     }
 }

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
@@ -120,6 +120,11 @@ public interface TomcatPropertySet
     String CONNECTOR_SSL_PROTOCOL = "cargo.tomcat.connector.sslProtocol";
 
     /**
+     * The maximum HTTP header size.
+     */
+    String CONNECTOR_MAX_HTTP_HEADER_SIZE = "cargo.tomcat.connector.maxHttpHeaderSize";
+
+    /**
      * Custom valves defined as properties separated by <code>|</code><br>
      * Maven example:<br>
      * <code>

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/Tomcat5x6xStandaloneLocalConfigurationCapability.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/Tomcat5x6xStandaloneLocalConfigurationCapability.java
@@ -44,6 +44,7 @@ public class Tomcat5x6xStandaloneLocalConfigurationCapability extends
         this.propertySupportMap.put(TomcatPropertySet.CONNECTOR_TRUST_STORE_PASSWORD, Boolean.TRUE);
         this.propertySupportMap.put(TomcatPropertySet.CONNECTOR_CLIENT_AUTH, Boolean.TRUE);
         this.propertySupportMap.put(TomcatPropertySet.CONNECTOR_SSL_PROTOCOL, Boolean.TRUE);
+        this.propertySupportMap.put(TomcatPropertySet.CONNECTOR_MAX_HTTP_HEADER_SIZE, Boolean.TRUE);
     }
 
 }


### PR DESCRIPTION
In cases when JWTs are stored as cookies, or large Kerberos tokens are being transmitted over the network, having control over the maxHttpHeaderSize setting can make all the difference between failed and successful tests. The below changes should add support for the maxHttpHeaderSize setting, which appears to be supported across Tomcat 4.x-9.x.