### PR TITLE
Using more advanced technique to test wildfly availability

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/spi/startup/CombinedContainerMonitor.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/spi/startup/CombinedContainerMonitor.java
@@ -1,3 +1,22 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2018 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
 package org.codehaus.cargo.container.spi.startup;
 
 import java.util.Arrays;

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/spi/startup/CombinedContainerMonitor.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/spi/startup/CombinedContainerMonitor.java
@@ -1,0 +1,52 @@
+package org.codehaus.cargo.container.spi.startup;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.codehaus.cargo.container.Container;
+import org.codehaus.cargo.container.startup.ContainerMonitor;
+
+/**
+ * Monitor which gathers information from multiple monitors.
+ */
+public class CombinedContainerMonitor extends AbstractContainerMonitor 
+{
+
+    /**
+     * Underlying monitors
+     */
+    private final List<ContainerMonitor> monitors;
+
+    /**
+     * Constructor.
+     *
+     * @param container Container to be monitored.
+     * @param monitors Underlying monitors
+     */
+    public CombinedContainerMonitor(Container container, ContainerMonitor... monitors)
+    {
+        super(container);
+        if (monitors == null || monitors.length == 0) 
+        {
+            throw new IllegalArgumentException("Specify at least one monitor");
+        }
+        this.monitors = Arrays.asList(monitors);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() 
+    {
+        for (ContainerMonitor monitor : monitors)
+        {
+            if (!monitor.isRunning()) 
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/AbstractWildFlyInstalledLocalContainer.java
+++ b/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/AbstractWildFlyInstalledLocalContainer.java
@@ -38,6 +38,8 @@ import org.codehaus.cargo.container.jboss.internal.JBoss7xContainerCapability;
 import org.codehaus.cargo.container.property.GeneralPropertySet;
 import org.codehaus.cargo.container.spi.AbstractInstalledLocalContainer;
 import org.codehaus.cargo.container.spi.jvm.JvmLauncher;
+import org.codehaus.cargo.container.spi.startup.CombinedContainerMonitor;
+import org.codehaus.cargo.container.startup.ContainerMonitor;
 import org.codehaus.cargo.container.wildfly.internal.configuration.factory.WildFlyCliConfigurationFactory;
 import org.codehaus.cargo.util.CargoException;
 
@@ -376,7 +378,9 @@ public abstract class AbstractWildFlyInstalledLocalContainer extends AbstractIns
     {
         if (waitForStarting)
         {
-            waitForStarting(new CLIWildFlyMonitor(this));
+            ContainerMonitor first = new ManagementUrlWildFlyMonitor(this);
+            ContainerMonitor second = new CLIWildFlyMonitor(this);
+            waitForStarting(new CombinedContainerMonitor(this, first, second));
         }
         else
         {

--- a/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/AbstractWildFlyInstalledLocalContainer.java
+++ b/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/AbstractWildFlyInstalledLocalContainer.java
@@ -376,7 +376,7 @@ public abstract class AbstractWildFlyInstalledLocalContainer extends AbstractIns
     {
         if (waitForStarting)
         {
-            waitForStarting(new ManagementUrlWildFlyMonitor(this));
+            waitForStarting(new CLIWildFlyMonitor(this));
         }
         else
         {

--- a/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
+++ b/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
@@ -35,11 +35,6 @@ public class CLIWildFlyMonitor extends AbstractContainerMonitor
 {
 
     /**
-     * Url monitor to perform http checks
-     */
-    private final ManagementUrlWildFlyMonitor managementUrlWildFlyMonitor;
-
-    /**
      * Constructor.
      *
      * @param container Container to be monitored.
@@ -47,7 +42,6 @@ public class CLIWildFlyMonitor extends AbstractContainerMonitor
     public CLIWildFlyMonitor(ScriptingCapableContainer container) 
     {
         super(container);
-        managementUrlWildFlyMonitor = new ManagementUrlWildFlyMonitor(container);
     }
 
     /**
@@ -56,11 +50,6 @@ public class CLIWildFlyMonitor extends AbstractContainerMonitor
     @Override
     public boolean isRunning() 
     {
-        // first check whether management console is available
-        if (!managementUrlWildFlyMonitor.isRunning())
-        {
-            return false;
-        }
         WildFlyConfiguration configuration = (WildFlyConfiguration) getConfiguration();
         WildFlyCliConfigurationFactory factory = configuration.getConfigurationFactory();
         List<ScriptCommand> configurationScript = new ArrayList<ScriptCommand>();

--- a/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
+++ b/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
@@ -25,13 +25,19 @@ import java.util.List;
 import org.codehaus.cargo.container.ContainerException;
 import org.codehaus.cargo.container.ScriptingCapableContainer;
 import org.codehaus.cargo.container.configuration.script.ScriptCommand;
+import org.codehaus.cargo.container.spi.startup.AbstractContainerMonitor;
 import org.codehaus.cargo.container.wildfly.internal.configuration.factory.WildFlyCliConfigurationFactory;
 
 /**
  * WildFly monitor checking if CLI API is available.
  */
-public class CLIWildFlyMonitor extends ManagementUrlWildFlyMonitor
+public class CLIWildFlyMonitor extends AbstractContainerMonitor
 {
+
+    /**
+     * Url monitor to perform http checks
+     */
+    private final ManagementUrlWildFlyMonitor managementUrlWildFlyMonitor;
 
     /**
      * Constructor.
@@ -41,6 +47,7 @@ public class CLIWildFlyMonitor extends ManagementUrlWildFlyMonitor
     public CLIWildFlyMonitor(ScriptingCapableContainer container) 
     {
         super(container);
+        managementUrlWildFlyMonitor = new ManagementUrlWildFlyMonitor(container);
     }
 
     /**
@@ -49,7 +56,8 @@ public class CLIWildFlyMonitor extends ManagementUrlWildFlyMonitor
     @Override
     public boolean isRunning() 
     {
-        if (!super.isRunning())
+        // first check whether management console is available
+        if (!managementUrlWildFlyMonitor.isRunning())
         {
             return false;
         }

--- a/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
+++ b/core/containers/wildfly/src/main/java/org/codehaus/cargo/container/wildfly/internal/CLIWildFlyMonitor.java
@@ -1,0 +1,71 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2018 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.container.wildfly.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.cargo.container.ContainerException;
+import org.codehaus.cargo.container.ScriptingCapableContainer;
+import org.codehaus.cargo.container.configuration.script.ScriptCommand;
+import org.codehaus.cargo.container.wildfly.internal.configuration.factory.WildFlyCliConfigurationFactory;
+
+/**
+ * WildFly monitor checking if CLI API is available.
+ */
+public class CLIWildFlyMonitor extends ManagementUrlWildFlyMonitor
+{
+
+    /**
+     * Constructor.
+     *
+     * @param container Container to be monitored.
+     */
+    public CLIWildFlyMonitor(ScriptingCapableContainer container) 
+    {
+        super(container);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunning() 
+    {
+        if (!super.isRunning())
+        {
+            return false;
+        }
+        WildFlyConfiguration configuration = (WildFlyConfiguration) getConfiguration();
+        WildFlyCliConfigurationFactory factory = configuration.getConfigurationFactory();
+        List<ScriptCommand> configurationScript = new ArrayList<ScriptCommand>();
+        configurationScript.add(factory.connectToServerScript());
+        try 
+        {
+            ((ScriptingCapableContainer) getContainer()).executeScript(configurationScript);
+            return true;
+        } 
+        catch (ContainerException ex) 
+        {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
Wildfly starts management interface too early: when server is not yet fully booted management interface is already reachable in terms of tcp connectivity. The idea is to ping wildfly via CLI API to determine whether it is fully booted or not:

```
~$ java -jar jboss-modules.jar -mp modules org.jboss.as.cli --file=connect.cli
INFO  [org.jboss.modules] JBoss Modules version 1.5.2.Final
INFO  [org.xnio] XNIO version 3.4.0.Final
INFO  [org.xnio.nio] XNIO NIO Implementation Version 3.4.0.Final
INFO  [org.jboss.remoting] JBoss Remoting version 4.0.21.Final
ERROR [org.jboss.as.cli.CommandContext] Timeout waiting for the system to boot.
Timeout waiting for the system to boot.
~$ echo $?
1
~$ 
```