### PR TITLE
CARGO-1453: Improve Loading of Jar in Tomcat when Using Resources Mecanism

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
@@ -46,6 +46,14 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
      */
     protected static final String JAR_RESOURCE_SET =
         "org.apache.catalina.webresources.JarResourceSet";
+    
+    /**
+     * For further details, see
+     * <a href="http://tomcat.apache.org/tomcat-8.0-doc/config/resources.html">Apache Tomcat 8
+     * Configuration Reference</a>, in particular the <code>FileResourceSet</code> section.
+     */
+    protected static final String FILE_RESOURCE_SET =
+        "org.apache.catalina.webresources.FileResourceSet";
 
     /**
      * {@inheritDoc}
@@ -73,7 +81,6 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
         {
             sb.append("<PostResources ");
             writePostResource(path, sb);
-            sb.append("\" webAppMount=\"/WEB-INF/classes");
             sb.append("\" />");
         }
         sb.append("</Resources>");
@@ -97,7 +104,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
             }
             else
             {
-                resources = context.getOwnerDocument().createElement("Loader");
+                resources = context.getOwnerDocument().createElement("Resources");
                 context.appendChild(resources);
             }
 
@@ -106,7 +113,6 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
                 Element postResource = resources.getOwnerDocument().createElement("PostResources");
                 resources.appendChild(postResource);
                 writePostResource(path, postResource);
-                postResource.setAttribute("webAppMount", "/WEB-INF/classes");
             }
         }
     }
@@ -165,6 +171,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
     {
         sb.append("className=\"" + DIR_RESOURCE_SET + "\" base=\"");
         sb.append(path.replace("&", "&amp;"));
+        sb.append("\" webAppMount=\"/WEB-INF/classes");
     }
 
     /**
@@ -177,6 +184,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
     {
         postResourceEl.setAttribute("className", DIR_RESOURCE_SET);
         postResourceEl.setAttribute("base", path.replace("&", "&amp;"));
+        postResourceEl.setAttribute("webAppMount", "/WEB-INF/classes");
     }
 
     /**
@@ -187,8 +195,10 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
      */
     private void writeJarPostResource(StringBuilder sb, String path)
     {
-        sb.append("className=\"" + JAR_RESOURCE_SET + "\" base=\"");
+        sb.append("className=\"" + FILE_RESOURCE_SET + "\" base=\"");
         sb.append(path.replace("&", "&amp;"));
+        sb.append("\" webAppMount=\"/WEB-INF/lib/");
+        sb.append(getFileHandler().getName(path).replace("&", "&amp;"));
     }
 
     /**
@@ -199,8 +209,10 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
      */
     private void writeJarPostResource(Element postResourceEl, String path)
     {
-        postResourceEl.setAttribute("className", JAR_RESOURCE_SET);
+        postResourceEl.setAttribute("className", FILE_RESOURCE_SET);
         postResourceEl.setAttribute("base", path.replace("&", "&amp;"));
+        postResourceEl.setAttribute("webAppMount", "/WEB-INF/lib/"
+            + getFileHandler().getName(path).replace("&", "&amp;"));
     }
 
     /**
@@ -215,6 +227,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
         sb.append(getFileHandler().getParent(path).replace("&", "&amp;"));
         sb.append("\" internalPath=\"");
         sb.append(getFileHandler().getName(path).replace("&", "&amp;"));
+        sb.append("\" webAppMount=\"/WEB-INF/classes");
     }
 
     /**
@@ -230,6 +243,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
             getFileHandler().getParent(path).replace("&", "&amp;"));
         postResourceEl.setAttribute("internalPath",
             getFileHandler().getName(path).replace("&", "&amp;"));
+        postResourceEl.setAttribute("webAppMount", "/WEB-INF/classes");
     }
 
     /**

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
@@ -107,8 +107,8 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         // path defined in its context.xml file.
         File artifactDir = new File(getTestData().targetDir).getParentFile();
         Copy copyTask = (Copy) new AntUtils().createProject().createTask("copy");
-        copyTask.setTofile(new File(artifactDir, "tomcatcontext-war-link-simple-jar.war"));
-        copyTask.setFile(new File(getTestData().getTestDataFileFor("tomcatcontext-war-link-simple-jar")));
+        copyTask.setTofile(new File(artifactDir, "tomcat-context.war"));
+        copyTask.setFile(new File(getTestData().getTestDataFileFor("tomcatcontext-war")));
         copyTask.execute();
         
         String simpleJar = System.getProperty("cargo.testdata.simple-jar");
@@ -119,7 +119,7 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         }
 
         WAR war = (WAR) new DefaultDeployableFactory().createDeployable(getContainer().getId(),
-            new File(artifactDir, "tomcatcontext-war-link-simple-jar.war").getPath(), DeployableType.WAR);
+            new File(artifactDir, "tomcat-context.war").getPath(), DeployableType.WAR);
         war.setExtraClasspath(new String[] {simpleJar});
 
         getLocalContainer().getConfiguration().addDeployable(war);
@@ -134,7 +134,7 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         getLocalContainer().stop();
         PingUtils.assertPingFalse("tomcat context war not stopped", warPingURL, getLogger());
     }
-
+    
     /**
      * Tests that a servlet has access to a class in added to the extraclasspath
      * with expanded WAR with a <code>context.xml</code> file.
@@ -146,7 +146,7 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         File artifactDir = new File(getTestData().targetDir).getParentFile();
         Expand expandTask = (Expand) new AntUtils().createProject().createTask("unwar");
         expandTask.setDest(new File(artifactDir, "tomcat-context"));
-        expandTask.setSrc(new File(getTestData().getTestDataFileFor("tomcatcontext-war")));
+        expandTask.setSrc(new File(getTestData().getTestDataFileFor("tomcatcontext-war-link-simple-jar")));
         expandTask.execute();
         
         String simpleJar = System.getProperty("cargo.testdata.simple-jar");
@@ -172,4 +172,6 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         getLocalContainer().stop();
         PingUtils.assertPingFalse("tomcat context war not stopped", warPingURL, getLogger());
     }
+
+
 }

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
@@ -146,7 +146,8 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         File artifactDir = new File(getTestData().targetDir).getParentFile();
         Expand expandTask = (Expand) new AntUtils().createProject().createTask("unwar");
         expandTask.setDest(new File(artifactDir, "tomcat-context"));
-        expandTask.setSrc(new File(getTestData().getTestDataFileFor("tomcatcontext-war-link-simple-jar")));
+        expandTask.setSrc(new File(getTestData().getTestDataFileFor("tomcatcontext-war-link-simple"
+                + "-jar")));
         expandTask.execute();
         
         String simpleJar = System.getProperty("cargo.testdata.simple-jar");

--- a/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
+++ b/core/samples/java/src/test/java/org/codehaus/cargo/sample/java/tomcat/WarExtraClasspathWithContextTest.java
@@ -107,8 +107,8 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         // path defined in its context.xml file.
         File artifactDir = new File(getTestData().targetDir).getParentFile();
         Copy copyTask = (Copy) new AntUtils().createProject().createTask("copy");
-        copyTask.setTofile(new File(artifactDir, "tomcat-context.war"));
-        copyTask.setFile(new File(getTestData().getTestDataFileFor("tomcatcontext-war")));
+        copyTask.setTofile(new File(artifactDir, "tomcatcontext-war-link-simple-jar.war"));
+        copyTask.setFile(new File(getTestData().getTestDataFileFor("tomcatcontext-war-link-simple-jar")));
         copyTask.execute();
         
         String simpleJar = System.getProperty("cargo.testdata.simple-jar");
@@ -119,7 +119,7 @@ public class WarExtraClasspathWithContextTest extends AbstractCargoTestCase
         }
 
         WAR war = (WAR) new DefaultDeployableFactory().createDeployable(getContainer().getId(),
-            new File(artifactDir, "tomcat-context.war").getPath(), DeployableType.WAR);
+            new File(artifactDir, "tomcatcontext-war-link-simple-jar.war").getPath(), DeployableType.WAR);
         war.setExtraClasspath(new String[] {simpleJar});
 
         getLocalContainer().getConfiguration().addDeployable(war);

--- a/core/samples/pom.xml
+++ b/core/samples/pom.xml
@@ -826,7 +826,7 @@
                 <name>cargo.tomcat9x.java.home</name>
                 <value>${cargo.java.home.1_8}</value>
               </property>
-  
+
               <property>
                 <name>cargo.tomee1x.url</name>
                 <value>http://archive.apache.org/dist/tomee/tomee-1.7.5/apache-tomee-1.7.5-plus.zip</value>
@@ -835,7 +835,7 @@
                 <name>cargo.tomee1x.java.home</name>
                 <value>${cargo.java.home.1_6}</value>
               </property>
-  
+
               <property>
                 <name>cargo.tomee7x.url</name>
                 <value>http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/7.0.4/apache-tomee-7.0.4-plus.zip</value>
@@ -1487,6 +1487,13 @@
                   <type>war</type>
                   <outputDirectory>${project.build.directory}/deployables</outputDirectory>
                   <destFileName>tomcatcontext-war.war</destFileName>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.codehaus.cargo</groupId>
+                  <artifactId>tomcatcontext-war-link-simple-jar</artifactId>
+                  <type>war</type>
+                  <outputDirectory>${project.build.directory}/deployables</outputDirectory>
+                  <destFileName>tomcatcontext-war-link-simple-jar.war</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.codehaus.cargo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
   <scm>
     <connection>scm:git:https://github.com/codehaus-cargo/cargo.git</connection>
     <developerConnection>scm:git:https://github.com/codehaus-cargo/cargo.git</developerConnection>
-    <url>https://github.com/codehaus-cargo/cargo</url> 
+    <url>https://github.com/codehaus-cargo/cargo</url>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>
@@ -445,7 +445,7 @@
       <dependency>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-core-container-liberty</artifactId>
-        <version>${project.version}</version>        
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.cargo</groupId>
@@ -658,6 +658,12 @@
       <dependency>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>tomcatcontext-war</artifactId>
+        <version>${project.version}</version>
+        <type>war</type>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>tomcatcontext-war-link-simple-jar</artifactId>
         <version>${project.version}</version>
         <type>war</type>
       </dependency>

--- a/resources/testdata/pom.xml
+++ b/resources/testdata/pom.xml
@@ -46,6 +46,7 @@
     <module>authentication-war</module>
     <module>expanded-war</module>
     <module>tomcat-context</module>
+    <module>tomcat-context-link-simple-jar</module>
     <module>simple-bundle</module>
     <module>simple-har</module>
     <module>simple-aop</module>

--- a/resources/testdata/tomcat-context-link-simple-jar/pom.xml
+++ b/resources/testdata/tomcat-context-link-simple-jar/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2018 Ali Tokmen.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.cargo</groupId>
+    <artifactId>cargo-samples-testdata</artifactId>
+    <version>1.6.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>tomcatcontext-war-link-simple-jar</artifactId>
+  <name>Cargo Tomcat context WAR with link to simple jar test data for samples</name>
+  <packaging>war</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>simple-jar</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/resources/testdata/tomcat-context-link-simple-jar/src/main/java/org/codehaus/cargo/sample/testdata/tomcatcontext/TestServlet.java
+++ b/resources/testdata/tomcat-context-link-simple-jar/src/main/java/org/codehaus/cargo/sample/testdata/tomcatcontext/TestServlet.java
@@ -1,0 +1,49 @@
+/*
+ * ========================================================================
+ *
+ * Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2018 Ali Tokmen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================================================================
+ */
+package org.codehaus.cargo.sample.testdata.tomcatcontext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.codehaus.cargo.simple.SimpleClass;
+
+/**
+ * Sample test Servlet used to verify that parameters passed in Tomcat's <code>context.xml</code>
+ * file are correctly passed to Tomcat when the WAR module is deployed.
+ */
+public class TestServlet extends HttpServlet
+{
+    @Override
+    public void doGet(HttpServletRequest request,
+        HttpServletResponse response) throws ServletException, IOException
+    {
+        SimpleClass simpleClass = new SimpleClass();
+        String message = simpleClass.getMessage();
+        String value = getServletContext().getInitParameter("testcontextxml");
+        PrintWriter out = response.getWriter();
+        out.print("Test value is [" + value + "]");
+        out.close();
+    }
+}

--- a/resources/testdata/tomcat-context-link-simple-jar/src/main/webapp/META-INF/context.xml
+++ b/resources/testdata/tomcat-context-link-simple-jar/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,3 @@
+<Context path="/tomcat-context">
+  <Parameter name="testcontextxml" value="test value"/>
+</Context>

--- a/resources/testdata/tomcat-context-link-simple-jar/src/main/webapp/WEB-INF/web.xml
+++ b/resources/testdata/tomcat-context-link-simple-jar/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!DOCTYPE web-app PUBLIC 
+     "-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN"
+    "http://java.sun.com/j2ee/dtds/web-app_2_2.dtd">
+
+<web-app>
+  <description>Simple Webapp for testing</description>
+  <servlet>
+    <servlet-name>test</servlet-name>
+    <servlet-class>org.codehaus.cargo.sample.testdata.tomcatcontext.TestServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>test</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping> 
+</web-app>


### PR DESCRIPTION
Hi, this PR intend to fix https://codehaus-cargo.atlassian.net/projects/CARGO/issues/CARGO-1453, and like I said in the last comment, fix the actual bug in Tomcat8xStandaloneLocalConfiguration#configureExtraClasspathToken because the wrong xml tag if added if the tag "Resources" is not present in context.xml file. I think an additionnal test will be great to detect this error.