### PR TITLE
Doctype HTML5

### DIFF
--- a/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/CargoDaemonServlet.java
+++ b/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/CargoDaemonServlet.java
@@ -364,7 +364,7 @@ public class CargoDaemonServlet extends HttpServlet implements Runnable
                 
                 long filesize = fileManager.getFileSize(logFilePath);
 
-                response.setContentType("text/plain");
+                response.setContentType("text/html");
                 response.setCharacterEncoding("UTF-8");
                 response.setHeader("X-Text-Size", String.valueOf(filesize));
 

--- a/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/CargoDaemonServlet.java
+++ b/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/CargoDaemonServlet.java
@@ -1053,12 +1053,11 @@ public class CargoDaemonServlet extends HttpServlet implements Runnable
      */
     private void outputLogPageHeader(ServletOutputStream outputStream) throws Exception 
     {
-        outputStream.print("<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n"
-                + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \""
-                + "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-                + "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en-US\""
-                + "lang=\"en-US\">\n"
-                + "  <head profile=\"http://www.w3.org/2000/08/w3c-synd/#\">\n"
+        outputStream.print(""
+                + "<!doctype html>\n"
+                + "<html lang=\"en-US\">\n"
+                + "  <head>\n"
+                + "     <meta charset=\"utf-8\">\n"
                 + "     <style>\n"
                 + "       pre {\n" 
                 + "         margin: 0px;\n" 

--- a/extensions/daemon/webapp/src/main/webapp/index.html
+++ b/extensions/daemon/webapp/src/main/webapp/index.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!doctype html>
 <!--
   ~ Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2018 Ali Tokmen.
   ~
@@ -14,9 +14,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
-  <head profile="http://www.w3.org/2000/08/w3c-synd/#">
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="cargo.css" type="text/css"/>
     <title>Cargo Daemon</title>
     <script>


### PR DESCRIPTION
I use cargo daemon with windows and internet explorer.
I have issues with cargo daemon and IE. IE show index page and viewlog as XML, not as HTML.
I juste change doctype to HTML5, and it seems working on IE and Chrome.