### PR TITLE
Update container timeout from configuration if container already exists

### DIFF
--- a/extensions/maven2/plugin/src/main/java/org/codehaus/cargo/maven2/AbstractCargoMojo.java
+++ b/extensions/maven2/plugin/src/main/java/org/codehaus/cargo/maven2/AbstractCargoMojo.java
@@ -710,6 +710,8 @@ public abstract class AbstractCargoMojo extends AbstractCommonMojo
         }
         else if (getConfigurationElement() != null)
         {
+            getContainerElement().updateContainer(container, cargoProject);
+
             createDefaultContainerElementIfNecessary();
             org.codehaus.cargo.container.configuration.Configuration configuration =
                 createConfiguration();

--- a/extensions/maven2/plugin/src/main/java/org/codehaus/cargo/maven2/configuration/Container.java
+++ b/extensions/maven2/plugin/src/main/java/org/codehaus/cargo/maven2/configuration/Container.java
@@ -493,6 +493,22 @@ public class Container
         return container;
     }
 
+   /**
+    * Update container based on this configuration
+    * @param container Container
+    * @param cargoProject Cargo project.
+    */
+    public void updateContainer(org.codehaus.cargo.container.Container container,
+          CargoProject cargoProject)
+    {
+        if (!container.getType().isLocal())
+        {
+            return;
+        }
+
+        setupTimeout((LocalContainer) container, cargoProject);
+    }
+
     /**
      * Setup the embedded container's extra classpath.
      * @param container Container.


### PR DESCRIPTION
Currently method of create different timeouts for stoping and starting local container described  [here](https://codehaus-cargo.github.io/cargo/Container+Timeout.html) does not work.

First of all as far as I checked in code there is no configuration field timeout directly in _Configuration_ class. Currently it is inside _Container_ configuration class.

Second issue is that once container is initialized while executing _ContainerStartMojo_ it is cached in context and then retrieved from it when executing _ContainerStopMojo_ but without updating it with execution specific configuration.

Changes proposed in this commit are not ideal, but should do the job at least when it comes to _timeout_ property.