### PR TITLE
Add null check in Tomcat8xStandaloneLocalConfiguration, fix regression introduced in 1.4.19

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
@@ -79,11 +79,14 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
         String[] extraClasspath = TomcatUtils.getExtraClasspath(deployable);
         StringBuilder sb = new StringBuilder();
         sb.append("<Resources>");
-        for (String path : extraClasspath)
+        if (extraClasspath != null)
         {
-            sb.append("<PostResources ");
-            writePostResource(path, sb);
-            sb.append("\" />");
+            for (String path : extraClasspath)
+            {
+                sb.append("<PostResources ");
+                writePostResource(path, sb);
+                sb.append("\" />");
+            }
         }
         sb.append("</Resources>");
         return sb.toString();


### PR DESCRIPTION
Simple fix, our project was crashing with an NPE here, worked up until 1.4.18.