### PR TITLE
Enable option "cargo.weblogic.server" for remote deployments on WebLogic.

### DIFF
--- a/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogicWlstRuntimeConfigurationCapability.java
+++ b/core/containers/weblogic/src/main/java/org/codehaus/cargo/container/weblogic/internal/WebLogicWlstRuntimeConfigurationCapability.java
@@ -36,5 +36,6 @@ public class WebLogicWlstRuntimeConfigurationCapability extends
     {
         this.propertySupportMap.put(ServletPropertySet.PORT, Boolean.TRUE);
         this.propertySupportMap.put(WebLogicPropertySet.LOCAL_WEBLOGIC_HOME, Boolean.TRUE);
+        this.propertySupportMap.put(WebLogicPropertySet.SERVER, Boolean.TRUE);
     }
 }

--- a/core/containers/weblogic/src/main/resources/org/codehaus/cargo/container/internal/resources/weblogicWlst/deployment/deploy-deployable-online.py
+++ b/core/containers/weblogic/src/main/resources/org/codehaus/cargo/container/internal/resources/weblogicWlst/deployment/deploy-deployable-online.py
@@ -15,4 +15,4 @@
 """
 
 cd('/')
-deploy('@cargo.deployable.id@', path = '@cargo.deployable.path.absolute@', retireTimeout = -1, upload = 'True')
+deploy('@cargo.deployable.id@', path = '@cargo.deployable.path.absolute@', retireTimeout = -1, upload = 'True', targets = '@cargo.weblogic.server@')


### PR DESCRIPTION
Users will be able to select the servers destination of the deployment.