### PR TITLE
CARGO-1486: Refresh deployment descriptors to have updated license

### DIFF
--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/application_1_2.dtd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/application_1_2.dtd
@@ -1,76 +1,19 @@
 <!--
-Copyright 1999 Sun Microsystems, Inc. 901 San Antonio Road,
-Palo Alto, CA  94303, U.S.A.  All rights reserved.
- 
-This product or document is protected by copyright and distributed
-under licenses restricting its use, copying, distribution, and
-decompilation.  No part of this product or documentation may be
-reproduced in any form by any means without prior written authorization
-of Sun and its licensors, if any.  
 
-Third party software, including font technology, is copyrighted and 
-licensed from Sun suppliers. 
+    Copyright (c) 1999, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Sun, Sun Microsystems, the Sun Logo, Solaris, Java, JavaServer Pages, Java 
-Naming and Directory Interface, JDBC, JDK, JavaMail and Enterprise JavaBeans, 
-are trademarks or registered trademarks of Sun Microsystems, Inc in the U.S. 
-and other countries.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-All SPARC trademarks are used under license and are trademarks
-or registered trademarks of SPARC International, Inc.
-in the U.S. and other countries. Products bearing SPARC
-trademarks are based upon an architecture developed by Sun Microsystems, Inc. 
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-PostScript is a registered trademark of Adobe Systems, Inc. 
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
- 
-Federal Acquisitions: Commercial Software - Government Users Subject to 
-Standard License Terms and Conditions.
-
-
- 
-DOCUMENTATION IS PROVIDED "AS IS" AND ALL EXPRESS OR IMPLIED
-CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING ANY
-IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE OR NON-INFRINGEMENT, ARE DISCLAIMED, EXCEPT
-TO THE EXTENT THAT SUCH DISCLAIMERS ARE HELD TO BE LEGALLY
-INVALID.
-
-_________________________________________________________________________
-Copyright 1999 Sun Microsystems, Inc., 
-901 San Antonio Road, Palo Alto, CA  94303, Etats-Unis. 
-Tous droits re'serve's.
- 
-
-Ce produit ou document est prote'ge' par un copyright et distribue' avec 
-des licences qui en restreignent l'utilisation, la copie, la distribution,
-et la de'compilation.  Aucune partie de ce produit ou de sa documentation
-associe'e ne peut e^tre reproduite sous aucune forme, par quelque moyen 
-que ce soit, sans l'autorisation pre'alable et e'crite de Sun et de ses 
-bailleurs de licence, s'il y en a.  
-
-Le logiciel de'tenu par des tiers, et qui comprend la technologie 
-relative aux polices de caracte`res, est prote'ge' par un copyright 
-et licencie' par des fournisseurs de Sun.
- 
-Sun, Sun Microsystems, le logo Sun, Solaris, Java, JavaServer Pages, Java 
-Naming and Directory Interface, JDBC, JDK, JavaMail, et Enterprise JavaBeans,  
-sont des marques de fabrique ou des marques de'pose'es de Sun 
-Microsystems, Inc. aux Etats-Unis et dans d'autres pays.
- 
-Toutes les marques SPARC sont utilise'es sous licence et sont
-des marques de fabrique ou des marques de'pose'es de SPARC
-International, Inc. aux Etats-Unis et  dans
-d'autres pays. Les produits portant les marques SPARC sont
-base's sur une architecture de'veloppe'e par Sun Microsystems, Inc.  
-
-Postcript est une marque enregistre'e d'Adobe Systems Inc. 
- 
-LA DOCUMENTATION EST FOURNIE "EN L'ETAT" ET TOUTES AUTRES CONDITIONS,
-DECLARATIONS ET GARANTIES EXPRESSES OU TACITES SONT FORMELLEMENT EXCLUES,
-DANS LA MESURE AUTORISEE PAR LA LOI APPLICABLE, Y COMPRIS NOTAMMENT
-TOUTE GARANTIE IMPLICITE RELATIVE A LA QUALITE MARCHANDE, A L'APTITUDE
-A UNE UTILISATION PARTICULIERE OU A L'ABSENCE DE CONTREFACON.
 -->
 
 <!--

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/application_1_3.dtd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/application_1_3.dtd
@@ -1,78 +1,19 @@
 <!--
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, U.S.A.
-All rights reserved.
 
-Sun Microsystems, Inc. has intellectual property rights relating to
-technology embodied in the product that is described in this document.
-In particular, and without limitation, these intellectual property
-rights may include one or more of the U.S. patents listed at
-http://www.sun.com/patents and one or more additional patents or
-pending patent applications in the U.S. and in other countries.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-This document and the product to which it pertains are distributed
-under licenses restricting their use, copying, distribution, and
-decompilation.  This document may be reproduced and distributed but may
-not be changed without prior written authorization of Sun and its
-licensors, if any.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-Third-party software, including font technology, is copyrighted and
-licensed from Sun suppliers.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-Sun,  Sun Microsystems,  the Sun logo,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail and  and
-Enterprise JavaBeans are trademarks or registered trademarks of Sun
-Microsystems, Inc. in the U.S. and other countries.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
-Federal Acquisitions: Commercial Software - Government Users Subject to
-Standard License Terms and Conditions.
-
-DOCUMENTATION IS PROVIDED "AS IS" AND ALL EXPRESS OR IMPLIED
-CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING ANY IMPLIED
-WARRANTY OF MERCHANTABILITY, FITNESS FOR FOR A PARTICULAR PURPOSE OR
-NON-INFRINGEMENT, ARE DISCLAIMED, EXCEPT TO THE EXTENT THAT SUCH
-DISCLAIMERS ARE HELD TO BE LEGALLY INVALID.
-
-
-_________________________________________________________________________
-
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, E'tats-Unis.
-Tous droits re'serve's.
-
-Sun Microsystems, Inc. a les droits de proprie'te' intellectuels
-relatants a` la technologie incorpore'e dans le produit qui est de'crit
-dans ce document. En particulier, et sans la limitation, ces droits de
-proprie'te' intellectuels peuvent inclure un ou plus des brevets
-ame'ricains e'nume're's a` http://www.sun.com/patents et un ou les
-brevets plus supple'mentaires ou les applications de brevet en attente
-dans les E'tats-Unis et dans les autres pays.
-
-Ce produit ou document est prote'ge' par un copyright et distribue'
-avec des licences qui en restreignent l'utilisation, la copie, la
-distribution, et la de'compilation.  Ce documention associe n peut
-e^tre reproduite et distribuer, par quelque moyen que ce soit, sans
-l'autorisation pre'alable et e'crite de Sun et de ses bailleurs de
-licence, le cas e'che'ant.
-
-Le logiciel de'tenu par des tiers, et qui comprend la technologie
-relative aux polices de caracte`res, est prote'ge' par un copyright et
-licencie' par des fournisseurs de Sun.
-
-Sun,  Sun Microsystems,  le logo Sun,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail et  and
-Enterprise JavaBeans sont des marques de fabrique ou des marques
-de'pose'es de Sun Microsystems, Inc. aux E'tats-Unis et dans d'autres
-pays.
-
-LA DOCUMENTATION EST FOURNIE "EN L'E'TAT" ET TOUTES AUTRES CONDITIONS,
-DECLARATIONS ET GARANTIES EXPRESSES OU TACITES SONT FORMELLEMENT
-EXCLUES, DANS LA MESURE AUTORISEE PAR LA LOI APPLICABLE, Y COMPRIS
-NOTAMMENT TOUTE GARANTIE IMPLICITE RELATIVE A LA QUALITE MARCHANDE, A
-L'APTITUDE A UNE UTILISATION PARTICULIERE OU A L'ABSENCE DE
-CONTREFAC,ON.
 -->
 
 <!--

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/ejb-jar_2_0.dtd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/ejb-jar_2_0.dtd
@@ -1,78 +1,19 @@
 <!--
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, U.S.A.
-All rights reserved.
 
-Sun Microsystems, Inc. has intellectual property rights relating to
-technology embodied in the product that is described in this document.
-In particular, and without limitation, these intellectual property
-rights may include one or more of the U.S. patents listed at
-http://www.sun.com/patents and one or more additional patents or
-pending patent applications in the U.S. and in other countries.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-This document and the product to which it pertains are distributed
-under licenses restricting their use, copying, distribution, and
-decompilation.  This document may be reproduced and distributed but may
-not be changed without prior written authorization of Sun and its
-licensors, if any.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-Third-party software, including font technology, is copyrighted and
-licensed from Sun suppliers.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-Sun,  Sun Microsystems,  the Sun logo,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail and  and
-Enterprise JavaBeans are trademarks or registered trademarks of Sun
-Microsystems, Inc. in the U.S. and other countries.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
-Federal Acquisitions: Commercial Software - Government Users Subject to
-Standard License Terms and Conditions.
-
-DOCUMENTATION IS PROVIDED "AS IS" AND ALL EXPRESS OR IMPLIED
-CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING ANY IMPLIED
-WARRANTY OF MERCHANTABILITY, FITNESS FOR FOR A PARTICULAR PURPOSE OR
-NON-INFRINGEMENT, ARE DISCLAIMED, EXCEPT TO THE EXTENT THAT SUCH
-DISCLAIMERS ARE HELD TO BE LEGALLY INVALID.
-
-
-_________________________________________________________________________
-
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, E'tats-Unis.
-Tous droits re'serve's.
-
-Sun Microsystems, Inc. a les droits de proprie'te' intellectuels
-relatants a` la technologie incorpore'e dans le produit qui est de'crit
-dans ce document. En particulier, et sans la limitation, ces droits de
-proprie'te' intellectuels peuvent inclure un ou plus des brevets
-ame'ricains e'nume're's a` http://www.sun.com/patents et un ou les
-brevets plus supple'mentaires ou les applications de brevet en attente
-dans les E'tats-Unis et dans les autres pays.
-
-Ce produit ou document est prote'ge' par un copyright et distribue'
-avec des licences qui en restreignent l'utilisation, la copie, la
-distribution, et la de'compilation.  Ce documention associe n peut
-e^tre reproduite et distribuer, par quelque moyen que ce soit, sans
-l'autorisation pre'alable et e'crite de Sun et de ses bailleurs de
-licence, le cas e'che'ant.
-
-Le logiciel de'tenu par des tiers, et qui comprend la technologie
-relative aux polices de caracte`res, est prote'ge' par un copyright et
-licencie' par des fournisseurs de Sun.
-
-Sun,  Sun Microsystems,  le logo Sun,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail et  and
-Enterprise JavaBeans sont des marques de fabrique ou des marques
-de'pose'es de Sun Microsystems, Inc. aux E'tats-Unis et dans d'autres
-pays.
-
-LA DOCUMENTATION EST FOURNIE "EN L'E'TAT" ET TOUTES AUTRES CONDITIONS,
-DECLARATIONS ET GARANTIES EXPRESSES OU TACITES SONT FORMELLEMENT
-EXCLUES, DANS LA MESURE AUTORISEE PAR LA LOI APPLICABLE, Y COMPRIS
-NOTAMMENT TOUTE GARANTIE IMPLICITE RELATIVE A LA QUALITE MARCHANDE, A
-L'APTITUDE A UNE UTILISATION PARTICULIERE OU A L'ABSENCE DE
-CONTREFAC,ON.
 -->
 
 <!--
@@ -146,7 +87,7 @@ managed transaction demarcation.
 The acknowledge-mode element must be one of the two following:
 
 	<acknowledge-mode>Auto-acknowledge</acknowledge-mode>
-	<acknowledge-mode>Dups-ok-acknowledge</acknowledge-mode>
+	<acknowledge-mode>Dups-ok-acknowledge</acknowledgemode>
 
 Used in: message-driven
 -->
@@ -169,7 +110,6 @@ optional for the ejb-jar file producer.
 
 Used in: ejb-jar
 -->
-
 <!ELEMENT assembly-descriptor (security-role*, method-permission*,
 container-transaction*, exclude-list?)>
 
@@ -433,7 +373,6 @@ an enterprise bean's home. The declaration consists of:
 
 Used in: entity, message-driven, session
 -->
-
 <!ELEMENT ejb-ref (description?, ejb-ref-name, ejb-ref-type,
 		home, remote, ejb-link?)>
 
@@ -762,7 +701,6 @@ enterprise bean's local interface.
 Used in: ejb-local-ref, entity, session
 
 -->
-
 <!ELEMENT local (#PCDATA)>
 
 <!--
@@ -1211,7 +1149,6 @@ The reentrant element must be one of the two following:
 
 Used in: entity
 -->
-
 <!ELEMENT reentrant (#PCDATA)>
 
 <!--
@@ -1431,7 +1368,6 @@ Example:
 	<role-name>employee</role-name>
     </security-role>
 -->
-
 <!ELEMENT security-role (description?, role-name)>
 
 <!--
@@ -1596,7 +1532,6 @@ standard deployment descriptor.
 <!ATTLIST abstract-schema-name id ID #IMPLIED>
 <!ATTLIST acknowledge-mode id ID #IMPLIED>
 <!ATTLIST assembly-descriptor id ID #IMPLIED>
-
 <!ATTLIST cascade-delete id ID #IMPLIED>
 <!ATTLIST cmp-field id ID #IMPLIED>
 <!ATTLIST cmp-version id ID #IMPLIED>
@@ -1614,7 +1549,6 @@ standard deployment descriptor.
 <!ATTLIST ejb-local-ref id ID #IMPLIED>
 <!ATTLIST ejb-name id ID #IMPLIED>
 <!ATTLIST ejb-ql id ID #IMPLIED>
-
 <!ATTLIST ejb-ref id ID #IMPLIED>
 <!ATTLIST ejb-ref-name id ID #IMPLIED>
 <!ATTLIST ejb-ref-type id ID #IMPLIED>
@@ -1632,7 +1566,6 @@ standard deployment descriptor.
 <!ATTLIST field-name id ID #IMPLIED>
 <!ATTLIST home id ID #IMPLIED>
 <!ATTLIST large-icon id ID #IMPLIED>
-
 <!ATTLIST local id ID #IMPLIED>
 <!ATTLIST local-home id ID #IMPLIED>
 <!ATTLIST message-driven id ID #IMPLIED>
@@ -1650,7 +1583,6 @@ standard deployment descriptor.
 <!ATTLIST primkey-field id ID #IMPLIED>
 <!ATTLIST query id ID #IMPLIED>
 <!ATTLIST query-method id ID #IMPLIED>
-
 <!ATTLIST reentrant id ID #IMPLIED>
 <!ATTLIST relationship-role-source id ID #IMPLIED>
 <!ATTLIST relationships id ID #IMPLIED>
@@ -1668,7 +1600,6 @@ standard deployment descriptor.
 <!ATTLIST role-name id ID #IMPLIED>
 <!ATTLIST run-as id ID #IMPLIED>
 <!ATTLIST security-identity id ID #IMPLIED>
-
 <!ATTLIST security-role id ID #IMPLIED>
 <!ATTLIST security-role-ref id ID #IMPLIED>
 <!ATTLIST session id ID #IMPLIED>

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_2.dtd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_2.dtd
@@ -1,76 +1,19 @@
 <!--
-Copyright 1999 Sun Microsystems, Inc. 901 San Antonio Road,
-Palo Alto, CA  94303, U.S.A.  All rights reserved.
- 
-This product or document is protected by copyright and distributed
-under licenses restricting its use, copying, distribution, and
-decompilation.  No part of this product or documentation may be
-reproduced in any form by any means without prior written authorization
-of Sun and its licensors, if any.  
 
-Third party software, including font technology, is copyrighted and 
-licensed from Sun suppliers. 
+    Copyright (c) 1999, 2018 Oracle and/or its affiliates. All rights reserved.
 
-Sun, Sun Microsystems, the Sun Logo, Solaris, Java, JavaServer Pages, Java 
-Naming and Directory Interface, JDBC, JDK, JavaMail and Enterprise JavaBeans, 
-are trademarks or registered trademarks of Sun Microsystems, Inc in the U.S. 
-and other countries.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-All SPARC trademarks are used under license and are trademarks
-or registered trademarks of SPARC International, Inc.
-in the U.S. and other countries. Products bearing SPARC
-trademarks are based upon an architecture developed by Sun Microsystems, Inc. 
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-PostScript is a registered trademark of Adobe Systems, Inc. 
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
- 
-Federal Acquisitions: Commercial Software - Government Users Subject to 
-Standard License Terms and Conditions.
-
-
- 
-DOCUMENTATION IS PROVIDED "AS IS" AND ALL EXPRESS OR IMPLIED
-CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING ANY
-IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE OR NON-INFRINGEMENT, ARE DISCLAIMED, EXCEPT
-TO THE EXTENT THAT SUCH DISCLAIMERS ARE HELD TO BE LEGALLY
-INVALID.
-
-_________________________________________________________________________
-Copyright 1999 Sun Microsystems, Inc., 
-901 San Antonio Road, Palo Alto, CA  94303, Etats-Unis. 
-Tous droits re'serve's.
- 
-
-Ce produit ou document est prote'ge' par un copyright et distribue' avec 
-des licences qui en restreignent l'utilisation, la copie, la distribution,
-et la de'compilation.  Aucune partie de ce produit ou de sa documentation
-associe'e ne peut e^tre reproduite sous aucune forme, par quelque moyen 
-que ce soit, sans l'autorisation pre'alable et e'crite de Sun et de ses 
-bailleurs de licence, s'il y en a.  
-
-Le logiciel de'tenu par des tiers, et qui comprend la technologie 
-relative aux polices de caracte`res, est prote'ge' par un copyright 
-et licencie' par des fournisseurs de Sun.
- 
-Sun, Sun Microsystems, le logo Sun, Solaris, Java, JavaServer Pages, Java 
-Naming and Directory Interface, JDBC, JDK, JavaMail, et Enterprise JavaBeans,  
-sont des marques de fabrique ou des marques de'pose'es de Sun 
-Microsystems, Inc. aux Etats-Unis et dans d'autres pays.
- 
-Toutes les marques SPARC sont utilise'es sous licence et sont
-des marques de fabrique ou des marques de'pose'es de SPARC
-International, Inc. aux Etats-Unis et  dans
-d'autres pays. Les produits portant les marques SPARC sont
-base's sur une architecture de'veloppe'e par Sun Microsystems, Inc.  
-
-Postcript est une marque enregistre'e d'Adobe Systems Inc. 
- 
-LA DOCUMENTATION EST FOURNIE "EN L'ETAT" ET TOUTES AUTRES CONDITIONS,
-DECLARATIONS ET GARANTIES EXPRESSES OU TACITES SONT FORMELLEMENT EXCLUES,
-DANS LA MESURE AUTORISEE PAR LA LOI APPLICABLE, Y COMPRIS NOTAMMENT
-TOUTE GARANTIE IMPLICITE RELATIVE A LA QUALITE MARCHANDE, A L'APTITUDE
-A UNE UTILISATION PARTICULIERE OU A L'ABSENCE DE CONTREFACON.
 -->
 
 <!--

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_3.dtd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_3.dtd
@@ -1,78 +1,19 @@
 <!--
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, U.S.A.
-All rights reserved.
 
-Sun Microsystems, Inc. has intellectual property rights relating to
-technology embodied in the product that is described in this document.
-In particular, and without limitation, these intellectual property
-rights may include one or more of the U.S. patents listed at
-http://www.sun.com/patents and one or more additional patents or
-pending patent applications in the U.S. and in other countries.
+    Copyright (c) 2000, 2018 Oracle and/or its affiliates. All rights reserved.
 
-This document and the product to which it pertains are distributed
-under licenses restricting their use, copying, distribution, and
-decompilation.  This document may be reproduced and distributed but may
-not be changed without prior written authorization of Sun and its
-licensors, if any.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
 
-Third-party software, including font technology, is copyrighted and
-licensed from Sun suppliers.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
 
-Sun,  Sun Microsystems,  the Sun logo,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail and  and
-Enterprise JavaBeans are trademarks or registered trademarks of Sun
-Microsystems, Inc. in the U.S. and other countries.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
-Federal Acquisitions: Commercial Software - Government Users Subject to
-Standard License Terms and Conditions.
-
-DOCUMENTATION IS PROVIDED "AS IS" AND ALL EXPRESS OR IMPLIED
-CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING ANY IMPLIED
-WARRANTY OF MERCHANTABILITY, FITNESS FOR FOR A PARTICULAR PURPOSE OR
-NON-INFRINGEMENT, ARE DISCLAIMED, EXCEPT TO THE EXTENT THAT SUCH
-DISCLAIMERS ARE HELD TO BE LEGALLY INVALID.
-
-
-_________________________________________________________________________
-
-Copyright (c) 2000 Sun Microsystems, Inc.,
-901 San Antonio Road,
-Palo Alto, California 94303, E'tats-Unis.
-Tous droits re'serve's.
-
-Sun Microsystems, Inc. a les droits de proprie'te' intellectuels
-relatants a` la technologie incorpore'e dans le produit qui est de'crit
-dans ce document. En particulier, et sans la limitation, ces droits de
-proprie'te' intellectuels peuvent inclure un ou plus des brevets
-ame'ricains e'nume're's a` http://www.sun.com/patents et un ou les
-brevets plus supple'mentaires ou les applications de brevet en attente
-dans les E'tats-Unis et dans les autres pays.
-
-Ce produit ou document est prote'ge' par un copyright et distribue'
-avec des licences qui en restreignent l'utilisation, la copie, la
-distribution, et la de'compilation.  Ce documention associe n peut
-e^tre reproduite et distribuer, par quelque moyen que ce soit, sans
-l'autorisation pre'alable et e'crite de Sun et de ses bailleurs de
-licence, le cas e'che'ant.
-
-Le logiciel de'tenu par des tiers, et qui comprend la technologie
-relative aux polices de caracte`res, est prote'ge' par un copyright et
-licencie' par des fournisseurs de Sun.
-
-Sun,  Sun Microsystems,  le logo Sun,  Java,  JavaServer Pages,  Java
-Naming and Directory Interface,  JDBC,  JDK,  JavaMail et  and
-Enterprise JavaBeans sont des marques de fabrique ou des marques
-de'pose'es de Sun Microsystems, Inc. aux E'tats-Unis et dans d'autres
-pays.
-
-LA DOCUMENTATION EST FOURNIE "EN L'E'TAT" ET TOUTES AUTRES CONDITIONS,
-DECLARATIONS ET GARANTIES EXPRESSES OU TACITES SONT FORMELLEMENT
-EXCLUES, DANS LA MESURE AUTORISEE PAR LA LOI APPLICABLE, Y COMPRIS
-NOTAMMENT TOUTE GARANTIE IMPLICITE RELATIVE A LA QUALITE MARCHANDE, A
-L'APTITUDE A UNE UTILISATION PARTICULIERE OU A L'ABSENCE DE
-CONTREFAC,ON.
 -->
 
 <!--

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_4.xsd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_4.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
 	    xmlns:j2ee="http://java.sun.com/xml/ns/j2ee"
@@ -9,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)web-app_2_4.xsds	1.61 04/04/16
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 
@@ -1239,4 +1213,3 @@
   </xsd:complexType>
 
 </xsd:schema>
-

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_5.xsd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_2_5.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
 	    targetNamespace="http://java.sun.com/xml/ns/javaee"
 	    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,50 +27,6 @@
   <xsd:annotation>
     <xsd:documentation>
       @(#)web-app_2_5.xsds	1.68 07/03/09
-    </xsd:documentation>
-  </xsd:annotation>
-
-  <xsd:annotation>
-    <xsd:documentation>
-
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
-
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-
-      Contributor(s):
-
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
-
     </xsd:documentation>
   </xsd:annotation>
 
@@ -1272,4 +1246,3 @@
   </xsd:complexType>
 
 </xsd:schema>
-

--- a/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_3_0.xsd
+++ b/core/api/module/src/main/resources/org/codehaus/cargo/module/internal/resource/web-app_3_0.xsd
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
 <xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://java.sun.com/xml/ns/javaee"
             xmlns:javaee="http://java.sun.com/xml/ns/javaee"
@@ -9,50 +27,14 @@
   <xsd:annotation>
     <xsd:documentation>
 
-      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-      
-      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
-      
-      The contents of this file are subject to the terms of either the
-      GNU General Public License Version 2 only ("GPL") or the Common
-      Development and Distribution License("CDDL") (collectively, the
-      "License").  You may not use this file except in compliance with
-      the License. You can obtain a copy of the License at
-      https://glassfish.dev.java.net/public/CDDL+GPL.html or
-      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
-      specific language governing permissions and limitations under the
-      License.
-      
-      When distributing the software, include this License Header
-      Notice in each file and include the License file at
-      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
-      particular file as subject to the "Classpath" exception as
-      provided by Sun in the GPL Version 2 section of the License file
-      that accompanied this code.  If applicable, add the following
-      below the License Header, with the fields enclosed by brackets []
-      replaced by your own identifying information:
-      "Portions Copyrighted [year] [name of copyright owner]"
-      
-      Contributor(s):
-      
-      If you wish your version of this file to be governed by only the
-      CDDL or only the GPL Version 2, indicate your decision by adding
-      "[Contributor] elects to include this software in this
-      distribution under the [CDDL or GPL Version 2] license."  If you
-      don't indicate a single choice of license, a recipient has the
-      option to distribute your version of this file under either the
-      CDDL, the GPL Version 2 or to extend the choice of license to its
-      licensees as provided above.  However, if you add GPL Version 2
-      code and therefore, elected the GPL Version 2 license, then the
-      option applies only if the new code is made subject to such
-      option by the copyright holder.
+      $Id$
       
     </xsd:documentation>
   </xsd:annotation>
 
   <xsd:annotation>
     <xsd:documentation>
-      <![CDATA[[
+<![CDATA[[
       This is the XML Schema for the Servlet 3.0 deployment descriptor.
       The deployment descriptor must be named "WEB-INF/web.xml" in the
       web application's war file.  All Servlet deployment descriptors
@@ -77,7 +59,7 @@
       
       http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd
       
-      ]]>
+]]>
     </xsd:documentation>
   </xsd:annotation>
 

--- a/core/api/util/src/test/resources/jboss-standalone.xml
+++ b/core/api/util/src/test/resources/jboss-standalone.xml
@@ -1,23 +1,17 @@
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2011, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
+  ~ Codehaus CARGO, copyright 2004-2011 Vincent Massol, 2012-2019 Ali Tokmen.
   ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
+  ~      http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <server xmlns="urn:jboss:domain:1.0">


### PR DESCRIPTION
DTDs taken from https://github.com/eclipse-ee4j/glassfish/tree/master/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds
XSDs taken from https://github.com/eclipse-ee4j/glassfish/tree/master/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>