### PR TITLE
CARGO-1489: Incorrect license of cargo-core-uberjar

### DIFF
--- a/core/samples/pom.xml
+++ b/core/samples/pom.xml
@@ -32,6 +32,10 @@
       <groupId>org.codehaus.cargo</groupId>
       <artifactId>cargo-core-uberjar</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-container-jonas</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.codehaus.cargo</groupId>

--- a/core/uberjar/pom.xml
+++ b/core/uberjar/pom.xml
@@ -87,6 +87,18 @@
       <groupId>org.codehaus.cargo</groupId>
       <artifactId>cargo-core-container-wildfly-swarm</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-ejb_2.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-j2ee-deployment_1.1_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-j2ee-management_1.0_spec</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/core/uberjar/pom.xml
+++ b/core/uberjar/pom.xml
@@ -49,10 +49,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.cargo</groupId>
-      <artifactId>cargo-core-container-jonas</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.cargo</groupId>
       <artifactId>cargo-core-container-jrun</artifactId>
     </dependency>
     <dependency>
@@ -112,9 +108,6 @@
 
                   <!-- EJB, JSR-88 and JSR-160 -->
                   <include>org.apache.geronimo.specs:*</include>
-
-                  <!-- The JOnAS container uses the OW2 API -->
-                  <include>org.ow2.jonas.tools.configurator:*</include>
                 </includes>
                 <excludes>
                   <exclude>*:*:*:sources</exclude>
@@ -183,11 +176,6 @@
         <dependency>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-core-container-jo</artifactId>
-          <classifier>sources</classifier>
-        </dependency>
-        <dependency>
-          <groupId>org.codehaus.cargo</groupId>
-          <artifactId>cargo-core-container-jonas</artifactId>
           <classifier>sources</classifier>
         </dependency>
         <dependency>

--- a/core/uberjar/src/main/assembly/assembly-src.xml
+++ b/core/uberjar/src/main/assembly/assembly-src.xml
@@ -35,9 +35,6 @@
 
                   <!-- EJB, JSR-88 and JSR-160 -->
                   <include>org.apache.geronimo.specs:*:*:sources:*</include>
-
-                  <!-- The JOnAS container uses the OW2 API -->
-                  <include>org.ow2.jonas.tools.configurator:*:*:sources:*</include>
             </includes>
             <unpack>true</unpack>
             <unpackOptions>


### PR DESCRIPTION
after this change, if testing on JOnAs and using cargo-core-uberjar then dependency on jonas artifact must be explicitly added by the user to the pom

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>