### PR TITLE
CARGO-1489: Incorrect license of cargo-core-uberjar

### DIFF
--- a/core/samples/pom.xml
+++ b/core/samples/pom.xml
@@ -35,6 +35,11 @@
 
     <dependency>
       <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-container-jonas</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
       <artifactId>cargo-core-api-container</artifactId>
       <type>test-jar</type>
     </dependency>

--- a/core/uberjar/pom.xml
+++ b/core/uberjar/pom.xml
@@ -49,10 +49,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.cargo</groupId>
-      <artifactId>cargo-core-container-jonas</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.cargo</groupId>
       <artifactId>cargo-core-container-jrun</artifactId>
     </dependency>
     <dependency>
@@ -126,9 +122,6 @@
 
                   <!-- EJB, JSR-88 and JSR-160 -->
                   <include>org.apache.geronimo.specs</include>
-
-                  <!-- The JOnAS container uses the OW2 API -->
-                  <include>org.ow2.jonas.tools.configurator</include>
                 </includes>
                 <excludes>
                   <exclude>*:*:*:sources</exclude>

--- a/core/uberjar/src/main/assembly/assembly-src.xml
+++ b/core/uberjar/src/main/assembly/assembly-src.xml
@@ -32,6 +32,7 @@
       <fileMode>0644</fileMode>
       <includes>
         <include>org.codehaus.cargo:*:*:sources:*</include>
+        <include>org.apache.geronimo.specs:*:*:sources:*</include>
       </includes>
       <unpack>true</unpack>
       <unpackOptions>

--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-ejb_2.1_spec</artifactId>
+        <version>1.1</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-j2ee_1.4_spec</artifactId>
         <version>1.0</version>
       </dependency>
@@ -935,8 +941,20 @@
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-j2ee-deployment_1.1_spec</artifactId>
+        <version>1.1</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-j2ee-management_1.0_spec</artifactId>
         <version>1.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-j2ee-management_1.0_spec</artifactId>
+        <version>1.1</version>
+        <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
make sure jonas related sources and classes are removed from uberjar

jonas support is not included in uberjar anymore (no classes, no sources)