### PR TITLE
Add jaxpmodule app argument to jboss72x

### DIFF
--- a/core/containers/jboss/src/main/java/org/codehaus/cargo/container/jboss/JBoss72xInstalledLocalContainer.java
+++ b/core/containers/jboss/src/main/java/org/codehaus/cargo/container/jboss/JBoss72xInstalledLocalContainer.java
@@ -84,6 +84,7 @@ public class JBoss72xInstalledLocalContainer extends JBoss71xInstalledLocalConta
 
         java.addAppArguments(
             "-mp", modules,
+            "-jaxpmodule", "javax.xml.jaxp-provider",
             "org.jboss.as.standalone",
             "--server-config="
                 + getConfiguration().getPropertyValue(JBossPropertySet.CONFIGURATION) + ".xml");


### PR DESCRIPTION
Hi there,

* the JAXP provider is not used if the app argument is missing 
* this makes our deployment fail
* when starting a vanilla JBoss EAP (v. 6.1.0) this app argument is present

Cheers,
Tassilo