### PR TITLE
Fix CARGO-1482: Ant 1.10version incompatibility

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/ResourceUtils.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/ResourceUtils.java
@@ -38,7 +38,8 @@ import java.util.Vector;
 import org.apache.tools.ant.filters.util.ChainReaderHelper;
 import org.apache.tools.ant.types.FilterChain;
 import org.codehaus.cargo.util.CargoException;
-import org.codehaus.cargo.util.DefaultFileHandler;
+import org.codehaus.cargo.util.
+    ;
 import org.codehaus.cargo.util.FileHandler;
 import org.codehaus.cargo.util.log.LoggedObject;
 
@@ -283,7 +284,8 @@ public final class ResourceUtils extends LoggedObject
         Vector<FilterChain> filterChains = new Vector<FilterChain>();
         filterChains.add(filterChain);
         helper.setFilterChains(filterChains);
-        try (BufferedReader in = new BufferedReader(helper.getAssembledReader()))
+        try (BufferedReader in =
+                new BufferedReader(DefaultFileHandler.getAssembledReader(helper)))
         {
             String line;
             StringBuilder out = new StringBuilder();

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/ResourceUtils.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/util/ResourceUtils.java
@@ -38,8 +38,7 @@ import java.util.Vector;
 import org.apache.tools.ant.filters.util.ChainReaderHelper;
 import org.apache.tools.ant.types.FilterChain;
 import org.codehaus.cargo.util.CargoException;
-import org.codehaus.cargo.util.
-    ;
+import org.codehaus.cargo.util.DefaultFileHandler;
 import org.codehaus.cargo.util.FileHandler;
 import org.codehaus.cargo.util.log.LoggedObject;
 


### PR DESCRIPTION
Using Ant 1.10.* yields to NoSuchMethodError: o.a.t.ant.filters.util.ChainReaderHelper.getAssembledReader()Ljava/io/Reader;