### PR TITLE
Ability to specify timeout for "operation" with runtime Tomcat

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatRuntimeConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatRuntimeConfiguration.java
@@ -20,6 +20,7 @@
 package org.codehaus.cargo.container.tomcat;
 
 import org.codehaus.cargo.container.configuration.ConfigurationCapability;
+import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.spi.configuration.AbstractRuntimeConfiguration;
 import org.codehaus.cargo.container.tomcat.internal.TomcatRuntimeConfigurationCapability;
 
@@ -29,6 +30,8 @@ import org.codehaus.cargo.container.tomcat.internal.TomcatRuntimeConfigurationCa
  */
 public class TomcatRuntimeConfiguration extends AbstractRuntimeConfiguration
 {
+    private static final long TWO_HOURS = 2 * 60 * 60 * 1000;
+
     /**
      * Capability of the Tomcat runtime configuration.
      */
@@ -44,6 +47,7 @@ public class TomcatRuntimeConfiguration extends AbstractRuntimeConfiguration
         super();
 
         setProperty(TomcatPropertySet.DEPLOY_UPDATE, "false");
+        setProperty(RemotePropertySet.TIMEOUT, Long.toString(TWO_HOURS));
     }
 
     /**

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatRuntimeConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatRuntimeConfiguration.java
@@ -30,6 +30,9 @@ import org.codehaus.cargo.container.tomcat.internal.TomcatRuntimeConfigurationCa
  */
 public class TomcatRuntimeConfiguration extends AbstractRuntimeConfiguration
 {
+    /**
+     * Default timeout for Tomcat (in milliseconds).
+     */
     private static final long TWO_HOURS = 2 * 60 * 60 * 1000;
 
     /**

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/AbstractTomcatManagerDeployer.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/AbstractTomcatManagerDeployer.java
@@ -301,7 +301,8 @@ public abstract class AbstractTomcatManagerDeployer extends AbstractRemoteDeploy
         }
         int timeout = 0;
         String timeoutStr = configuration.getPropertyValue(RemotePropertySet.TIMEOUT);
-        if (timeoutStr != null && !timeoutStr.isEmpty()) {
+        if (timeoutStr != null && !timeoutStr.isEmpty()) 
+        {
             timeout = Integer.parseInt(timeoutStr);
         }
         manager = new TomcatManager(managerURL, username, password);

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/AbstractTomcatManagerDeployer.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/AbstractTomcatManagerDeployer.java
@@ -299,9 +299,15 @@ public abstract class AbstractTomcatManagerDeployer extends AbstractRemoteDeploy
             userAgent.append('/');
             userAgent.append(version);
         }
+        int timeout = 0;
+        String timeoutStr = configuration.getPropertyValue(RemotePropertySet.TIMEOUT);
+        if (timeoutStr != null && !timeoutStr.isEmpty()) {
+            timeout = Integer.parseInt(timeoutStr);
+        }
         manager = new TomcatManager(managerURL, username, password);
         manager.setLogger(getLogger());
         manager.setUserAgent(userAgent.toString());
+        manager.setTimeout(timeout);
 
         return manager;
     }

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
@@ -925,7 +925,8 @@ public class TomcatManager extends LoggedObject
      * 
      * @param timeout in milliseconds; max is Integer.MAX_VALUE
      */
-    public void setTimeout(int timeout) {
+    public void setTimeout(int timeout) 
+    {
         this.timeout = timeout;
     }
 }

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatManager.java
@@ -81,6 +81,11 @@ public class TomcatManager extends LoggedObject
     private MessageDigest md5;
 
     /**
+     * Operation timeout when communicating with Tomcat manager
+     */
+    private int timeout = 0;
+
+    /**
      * Creates a Tomcat manager wrapper for the specified URL that uses a username of
      * <code>admin</code>, an empty password and ISO-8859-1 URL encoding.
      * 
@@ -524,6 +529,11 @@ public class TomcatManager extends LoggedObject
         connection.setAllowUserInteraction(false);
         connection.setDoInput(true);
         connection.setUseCaches(false);
+        if (timeout > 0)
+        {
+            connection.setConnectTimeout(timeout);
+            connection.setReadTimeout(timeout);
+        }
 
         if (data == null)
         {
@@ -908,5 +918,14 @@ public class TomcatManager extends LoggedObject
             }
         }
         return TomcatDeployableStatus.NOT_FOUND;
+    }
+
+    /**
+     * Operation timeout when communicating with Tomcat manager
+     * 
+     * @param timeout in milliseconds; max is Integer.MAX_VALUE
+     */
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
     }
 }

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatRuntimeConfigurationCapability.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/TomcatRuntimeConfigurationCapability.java
@@ -39,6 +39,7 @@ public class TomcatRuntimeConfigurationCapability extends AbstractRuntimeConfigu
         this.propertySupportMap.put(GeneralPropertySet.PROTOCOL, Boolean.TRUE);
         this.propertySupportMap.put(ServletPropertySet.PORT, Boolean.TRUE);
         this.propertySupportMap.put(RemotePropertySet.URI, Boolean.TRUE);
+        this.propertySupportMap.put(RemotePropertySet.TIMEOUT, Boolean.TRUE);
         this.propertySupportMap.put(TomcatPropertySet.DEPLOY_UPDATE, Boolean.TRUE);
     }
 }


### PR DESCRIPTION
Such "operation" can be: list, undeploy, deploy etc.

This commit CHANGES current behavior, which is to wait FOREVER,
and sets the default timeout to TWO HOURS - because
"you should never ever wait forever"

Two hours was picked to cover "uploading" 500 MB file
over the 1000 Kbps network.

Connect timeout refers to the time to establish the initial connection,
before the start of sending/receiving bytes.

Read timeout refers to the duration between received/send bytes, so:
1. time to first byte
2. time between first and second byte
3. time between second and third byte and so on.