### PR TITLE
Document that Tomcat protocol class is supported for Tomcat 7 and up

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/Tomcat7xStandaloneLocalConfigurationCapability.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/internal/Tomcat7xStandaloneLocalConfigurationCapability.java
@@ -25,7 +25,7 @@ import org.codehaus.cargo.container.tomcat.TomcatPropertySet;
  * Capabilities of Tomcat's {@link AbstractCatalinaStandaloneLocalConfiguration} configuration.
  */
 public class Tomcat7xStandaloneLocalConfigurationCapability extends
-    Tomcat5xStandaloneLocalConfigurationCapability
+    Tomcat6xStandaloneLocalConfigurationCapability
 {
     /**
      * Initialize the configuration-specific supports Map.


### PR DESCRIPTION
 * The Tomcat7xStandaloneLocalConfigurationCapability extended the Tomcat5x capability, and was missing the property added for Tomcat6x