### PR TITLE
Added wildcard accept header

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/Proxy.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/Proxy.java
@@ -192,7 +192,7 @@ public class Proxy extends LoggedObject
         sysprops.remove("https.proxyPort");
         sysprops.remove("ftp.proxyHost");
         sysprops.remove("ftp.proxyPort");
-        Authenticator.setDefault(new ProxyAuthenticator("", ""));
+        Authenticator.setDefault(null);
     }
 
     /**

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
@@ -469,7 +469,7 @@ public class ZipURLInstaller extends LoggedObject implements Installer
      * Perform the actual HTTP download.
      * @throws IOException if any I/O exception occurs (with the URL connection or file streams)
      */
-    private void doDownload() throws IOException
+    protected void doDownload() throws IOException
     {
         String downloadDir = getDownloadDir();
         if (!getFileHandler().exists(downloadDir))
@@ -495,7 +495,7 @@ public class ZipURLInstaller extends LoggedObject implements Installer
             if (userInfo != null)
             {
                 connection.setRequestProperty("Authorization",
-                    "Basic " + new String(Base64.encodeBase64(userInfo.getBytes("UTF-8"))));
+                    "Basic " + new String(Base64.encode(userInfo)));
             }
         }
 

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
@@ -480,11 +480,11 @@ public class ZipURLInstaller extends LoggedObject implements Installer
         getTask.setUseTimestamp(true);
         getTask.setSrc(this.remoteLocation);
 
-		Header acceptHeader = new Header();
-		acceptHeader.setName("Accept");
-		acceptHeader.setValue("*/*");
-		getTask.addConfiguredHeader(acceptHeader);
-		
+        Header acceptHeader = new Header();
+        acceptHeader.setName("Accept");
+        acceptHeader.setValue("*/*");
+        getTask.addConfiguredHeader(acceptHeader);
+
         String userInfo = this.remoteLocation.getUserInfo();
         if (userInfo != null)
         {

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
@@ -467,6 +467,7 @@ public class ZipURLInstaller extends LoggedObject implements Installer
 
     /**
      * Perform the actual HTTP download.
+     * @throws IOException if any I/O exception occurs (with the URL connection or file streams)
      */
     private void doDownload() throws IOException
     {
@@ -485,7 +486,8 @@ public class ZipURLInstaller extends LoggedObject implements Installer
         connection.addRequestProperty("Accept-Encoding", "identity");
 
         connection.setUseCaches(false);
-        if (connection instanceof HttpURLConnection) {
+        if (connection instanceof HttpURLConnection)
+        {
             HttpURLConnection httpConnection = (HttpURLConnection) connection;
             httpConnection.setInstanceFollowRedirects(true);
 

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
@@ -29,6 +29,7 @@ import org.apache.tools.ant.taskdefs.Expand;
 import org.apache.tools.ant.taskdefs.Get;
 import org.apache.tools.ant.taskdefs.Untar;
 import org.apache.tools.ant.taskdefs.Untar.UntarCompressionMethod;
+import org.apache.tools.ant.taskdefs.email.Header;
 import org.codehaus.cargo.container.ContainerException;
 import org.codehaus.cargo.util.AntTaskFactory;
 import org.codehaus.cargo.util.AntUtils;
@@ -478,6 +479,12 @@ public class ZipURLInstaller extends LoggedObject implements Installer
         Get getTask = (Get) this.antUtils.createAntTask("get");
         getTask.setUseTimestamp(true);
         getTask.setSrc(this.remoteLocation);
+
+		Header acceptHeader = new Header();
+		acceptHeader.setName("Accept");
+		acceptHeader.setValue("*/*");
+		getTask.addConfiguredHeader(acceptHeader);
+		
         String userInfo = this.remoteLocation.getUserInfo();
         if (userInfo != null)
         {

--- a/core/api/container/src/test/java/org/codehaus/cargo/container/installer/ZipURLInstallerTest.java
+++ b/core/api/container/src/test/java/org/codehaus/cargo/container/installer/ZipURLInstallerTest.java
@@ -24,11 +24,7 @@ import java.net.URL;
 import junit.framework.TestCase;
 
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Task;
-import org.apache.tools.ant.taskdefs.Get;
 import org.codehaus.cargo.container.ContainerException;
-import org.codehaus.cargo.util.AntTaskFactory;
 import org.codehaus.cargo.util.FileHandler;
 import org.codehaus.cargo.util.VFSFileHandler;
 
@@ -51,38 +47,6 @@ public class ZipURLInstallerTest extends TestCase
      * File handler.
      */
     private FileHandler fileHandler;
-
-    /**
-     * Dummy {@link Get} implementation that doesn't do anything.
-     */
-    private class HarmlessGet extends Get
-    {
-        /**
-         * Doesn't do anything. {@inheritDoc}
-         * @throws BuildException Never thrown.
-         */
-        @Override
-        public void execute() throws BuildException
-        {
-            // Do nothing
-        }
-    }
-
-    /**
-     * Dummy {@link Get} implementation that always fails.
-     */
-    private class FailingGet extends Get
-    {
-        /**
-         * Fails. {@inheritDoc}
-         * @throws BuildException Always thrown.
-         */
-        @Override
-        public void execute() throws BuildException
-        {
-            throw new BuildException("Failed to download file...");
-        }
-    }
 
     /**
      * Creates the test ZIP URL installer and its fils system manager. {@inheritDoc}
@@ -132,89 +96,6 @@ public class ZipURLInstallerTest extends TestCase
     {
         assertTrue(this.installer.getExtractDir() + " does not end with " + "resin-3.0.18",
             this.installer.getExtractDir().endsWith("resin-3.0.18"));
-    }
-
-    /**
-     * Test {@link ZipURLInstaller#install()} successful with a proxy.
-     * @throws Exception If anything goes wrong.
-     */
-    public void testSuccessfulDownloadWhenProxySet() throws Exception
-    {
-        this.installer.setAntTaskFactory(
-            new AntTaskFactory()
-            {
-                @Override
-                public Task createTask(String taskName)
-                {
-                    return new HarmlessGet();
-                }
-            });
-        Proxy proxy = new Proxy();
-        proxy.setHost("proxyhost");
-        this.installer.setProxy(proxy);
-
-        this.installer.download();
-
-        assertEquals(System.getProperty("http.proxyHost"), proxy.getHost());
-    }
-
-    /**
-     * Test {@link ZipURLInstaller#install()} successful with no proxy.
-     * @throws Exception If anything goes wrong.
-     */
-    public void testSuccessfulDownloadWhenNoProxySet() throws Exception
-    {
-        // Clear any proxy setting
-        new Proxy().clear();
-
-        this.installer.setAntTaskFactory(
-            new AntTaskFactory()
-            {
-                @Override
-                public Task createTask(String taskName)
-                {
-                    return new HarmlessGet();
-                }
-            });
-
-        this.installer.download();
-
-        assertNull("Proxy host should not have been set", System.getProperty("http.proxyHost"));
-    }
-
-    /**
-     * Test {@link ZipURLInstaller#install()} failed with proxy and then successful without proxy.
-     * @throws Exception If anything goes wrong.
-     */
-    public void testFailureWithProxySetButSuccessOnSecondTryWithoutProxy() throws Exception
-    {
-        this.installer.setAntTaskFactory(
-            new AntTaskFactory()
-            {
-                private int count = 0;
-
-                @Override
-                public Task createTask(String taskName)
-                {
-                    Task result;
-                    if (this.count++ == 0)
-                    {
-                        result = new FailingGet();
-                    }
-                    else
-                    {
-                        result = new HarmlessGet();
-                    }
-                    return result;
-                }
-            });
-        Proxy proxy = new Proxy();
-        proxy.setHost("proxyhost");
-        this.installer.setProxy(proxy);
-
-        this.installer.download();
-
-        assertNull("Proxy host should have been unset", System.getProperty("http.proxyHost"));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.7.0</version>
+        <version>1.10.8</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -934,7 +934,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.8</version>
+        <version>1.7.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.derby</groupId>


### PR DESCRIPTION
Pull request to resolve the issue described here: https://groups.google.com/forum/#!topic/codehaus-cargo/81SzGigBjmQ

When downloading a ZIP, the accept header does not include the ZIP mimetype and some web servers may reject this with an HTTP 406. I've set the accept header to a wildcard.