### PR TITLE
Skip copying dependencies and running ant when skipTests is true

### DIFF
--- a/extensions/ant/samples/configurationFiles-xmlReplacements-test/pom.xml
+++ b/extensions/ant/samples/configurationFiles-xmlReplacements-test/pom.xml
@@ -41,6 +41,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <!-- Avoid CARGO-827: Cannot build on Windows -->
                 <replace file="${cargo-ant-buildfiles.directory}/build.xml">

--- a/extensions/ant/samples/daemon-test/pom.xml
+++ b/extensions/ant/samples/daemon-test/pom.xml
@@ -113,6 +113,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <outputDirectory>${cargo-test-applications.directory}</outputDirectory>
               <artifactItems>
                 <artifactItem>

--- a/extensions/ant/samples/datasource-test/pom.xml
+++ b/extensions/ant/samples/datasource-test/pom.xml
@@ -41,6 +41,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <outputDirectory>${cargo-test-applications.directory}</outputDirectory>
               <artifactItems>
                 <artifactItem>
@@ -68,6 +69,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <!-- Avoid CARGO-827: Cannot build on Windows -->
                 <replace file="${cargo-ant-buildfiles.directory}/build.xml">
@@ -88,6 +90,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <ant antfile="${cargo-ant-buildfiles.directory}/build.xml">
                   <target name="stop" />

--- a/extensions/ant/samples/remote-test/pom.xml
+++ b/extensions/ant/samples/remote-test/pom.xml
@@ -60,6 +60,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <outputDirectory>${cargo-test-applications.directory}</outputDirectory>
               <artifactItems>
                 <artifactItem>
@@ -83,6 +84,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <!-- Avoid CARGO-827: Cannot build on Windows -->
                 <replace file="${cargo-ant-buildfiles.directory}/build.xml">
@@ -104,6 +106,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <ant antfile="${cargo-ant-buildfiles.directory}/build.xml">
                   <target name="undeploy" />

--- a/extensions/ant/samples/users-test/pom.xml
+++ b/extensions/ant/samples/users-test/pom.xml
@@ -41,6 +41,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <outputDirectory>${cargo-test-applications.directory}</outputDirectory>
               <artifactItems>
                 <artifactItem>
@@ -64,6 +65,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <!-- Avoid CARGO-827: Cannot build on Windows -->
                 <replace file="${cargo-ant-buildfiles.directory}/build.xml">
@@ -84,6 +86,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
+              <skip>${skipTests}</skip>
               <target>
                 <ant antfile="${cargo-ant-buildfiles.directory}/build.xml">
                   <target name="stop" />


### PR DESCRIPTION
 * Without this properly configured, mvn install -DskipTests falls over with errors in each samples directory