### PR TITLE
Support customizing the tomcat connector protocol with more classes

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat6xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat6xStandaloneLocalConfiguration.java
@@ -44,9 +44,6 @@ public class Tomcat6xStandaloneLocalConfiguration extends Tomcat5xStandaloneLoca
     public Tomcat6xStandaloneLocalConfiguration(String dir)
     {
         super(dir);
-
-        addXmlReplacement("conf/server.xml", CONNECTOR_XPATH, "SSLEnabled",
-            TomcatPropertySet.HTTP_SECURE);
     }
 
     /**
@@ -65,7 +62,7 @@ public class Tomcat6xStandaloneLocalConfiguration extends Tomcat5xStandaloneLoca
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * the path to find the manager application is different between v5 and v6.
      */
     @Override
@@ -170,11 +167,13 @@ public class Tomcat6xStandaloneLocalConfiguration extends Tomcat5xStandaloneLoca
     @Override
     protected void performXmlReplacements(LocalContainer container)
     {
+        addXmlReplacement("conf/server.xml", connectorXpath(), "SSLEnabled",
+                TomcatPropertySet.HTTP_SECURE);
         String connectorProtocolClass = getPropertyValue(
                 TomcatPropertySet.CONNECTOR_PROTOCOL_CLASS);
         if (connectorProtocolClass != null)
         {
-            addXmlReplacement("conf/server.xml", CONNECTOR_XPATH, "protocol",
+            addXmlReplacement("conf/server.xml", connectorXpath(), "protocol",
                 connectorProtocolClass);
         }
 

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat7xStandaloneLocalConfiguration.java
@@ -67,7 +67,6 @@ public class Tomcat7xStandaloneLocalConfiguration extends Tomcat6xStandaloneLoca
 
         // CARGO-1271: Starting Tomcat 7 with Cargo logs warning on emptySessionPath
         getProperties().remove(TomcatPropertySet.CONNECTOR_EMPTY_SESSION_PATH);
-        removeXmlReplacement("conf/server.xml", CONNECTOR_XPATH, "emptySessionPath");
     }
 
     /**
@@ -154,6 +153,8 @@ public class Tomcat7xStandaloneLocalConfiguration extends Tomcat6xStandaloneLoca
     protected void performXmlReplacements(LocalContainer container)
     {
         String serverXmlFileName = "conf/server.xml";
+
+        removeXmlReplacement(serverXmlFileName, connectorXpath(), "emptySessionPath");
 
         String startStopThreads = getPropertyValue(TomcatPropertySet.HOST_STARTSTOPTHREADS);
         if (startStopThreads != null)

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
@@ -127,7 +127,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write post Resources using with a StringBuilder
-     * 
+     *
      * @param path will be in the post resource
      * @param sb the StringBuilder we fill
      */
@@ -149,7 +149,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write post Resources using with a PostResources xml element
-     * 
+     *
      * @param path will be in the post resource
      * @param postResourceEl the xml element we fill
      */
@@ -171,7 +171,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write directory post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param sb the StringBuilder we fill
      */
@@ -184,7 +184,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write directory post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param postResourceEl the xml element we fill
      */
@@ -197,7 +197,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write jar post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param sb the StringBuilder we fill
      */
@@ -211,7 +211,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write jar post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param postResourceEl the xml element we fill
      */
@@ -225,7 +225,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write file post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param sb the StringBuilder we fill
      */
@@ -240,7 +240,7 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
 
     /**
      * Write file post resource
-     * 
+     *
      * @param path will be in the post resource
      * @param postResourceEl the xml element we fill
      */
@@ -266,14 +266,14 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
             TomcatPropertySet.CONNECTOR_SSL_IMPLEMENTATION_NAME);
         if (sslImplementationName != null)
         {
-            addXmlReplacement(serverXmlFileName, CONNECTOR_XPATH, "sslImplementationName",
+            addXmlReplacement(serverXmlFileName, connectorXpath(), "sslImplementationName",
                 sslImplementationName);
         }
 
         if ("true".equalsIgnoreCase(
                 getPropertyValue(TomcatPropertySet.CONNECTOR_HTTP_UPGRADE_PROTOCOL)))
         {
-            addXmlReplacement(serverXmlFileName, CONNECTOR_XPATH + "/UpgradeProtocol", "className",
+            addXmlReplacement(serverXmlFileName, connectorXpath() + "/UpgradeProtocol", "className",
                 "org.apache.coyote.http2.Http2Protocol",
                     XmlReplacement.ReplacementBehavior.ADD_MISSING_NODES);
         }

--- a/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat6xStandaloneLocalConfigurationTest.java
+++ b/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat6xStandaloneLocalConfigurationTest.java
@@ -120,4 +120,22 @@ public class Tomcat6xStandaloneLocalConfigurationTest extends
         XMLAssert.assertXpathEvaluatesTo("org.apache.coyote.http11.Http11NioProtocol",
                 "//Server/Service/Connector[@port='8080']/@protocol", config);
     }
+
+    /**
+     * Assert that the attribute 'protocol' is overidden with the property's APR implementation
+     * value.
+     * @throws Exception If anything does wrong.
+     */
+    public void testConfigureSetsAprConnectorProtocol() throws Exception
+    {
+        configuration.setProperty(TomcatPropertySet.CONNECTOR_PROTOCOL_CLASS,
+                "org.apache.coyote.http11.Http11AprProtocol");
+
+        configuration.configure(container);
+
+        String config = configuration.getFileHandler().readTextFile(
+                configuration.getHome() + "/conf/server.xml", StandardCharsets.UTF_8);
+        XMLAssert.assertXpathEvaluatesTo("org.apache.coyote.http11.Http11AprProtocol",
+                "//Server/Service/Connector[@port='8080']/@protocol", config);
+    }
 }

--- a/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfigurationTest.java
+++ b/core/containers/tomcat/src/test/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfigurationTest.java
@@ -83,7 +83,7 @@ public class Tomcat8xStandaloneLocalConfigurationTest extends
 
     /**
      * Assert that the attribute 'sslImplementationName' isn't added if the property isn't set.
-     * 
+     *
      * @throws Exception If anything does wrong.
      */
     public void testConfigureWithoutSslImplementationName() throws Exception
@@ -98,7 +98,7 @@ public class Tomcat8xStandaloneLocalConfigurationTest extends
 
     /**
      * Assert that the attribute 'sslImplementationName' is overidden with the property's value.
-     * 
+     *
      * @throws Exception If anything does wrong.
      */
     public void testConfigureSetsSslImplementationName() throws Exception
@@ -117,7 +117,7 @@ public class Tomcat8xStandaloneLocalConfigurationTest extends
 
     /**
      * Assert that the element 'UpgradeProtocol' isn't present if the property isn't set.
-     * 
+     *
      * @throws Exception If anything does wrong.
      */
     public void testConfigureWithoutHttpUpgradeProtocol() throws Exception
@@ -133,8 +133,8 @@ public class Tomcat8xStandaloneLocalConfigurationTest extends
 
     /**
      * Assert that the element 'UpgradeProtocol' is added if the property is set.
-     * 
-     * @throws Exception If anything does wrong.
+     *
+     * @throws Exception If anything goes wrong.
      */
     public void testConfigureAddsHttpUpgradeProtocol() throws Exception
     {
@@ -144,6 +144,30 @@ public class Tomcat8xStandaloneLocalConfigurationTest extends
 
         String config = configuration.getFileHandler().readTextFile(
                 configuration.getHome() + "/conf/server.xml", StandardCharsets.UTF_8);
+        XMLAssert.assertXpathExists(
+                "//Server/Service/Connector[@port='8080']"
+                        + "/UpgradeProtocol[@className='org.apache.coyote.http2.Http2Protocol']",
+                config);
+    }
+
+    /**
+     * Tests that combining changing the connector protocol class with adding the http upgrade
+     * element works correctly.
+     *
+     * @throws Exception If anything goes wrong.
+     */
+    public void testConfigureAddHttpUpgradeToNio2Protocol() throws Exception
+    {
+        configuration.setProperty(TomcatPropertySet.CONNECTOR_PROTOCOL_CLASS,
+                "org.apache.coyote.http11.Http11Nio2Protocol");
+        configuration.setProperty(TomcatPropertySet.CONNECTOR_HTTP_UPGRADE_PROTOCOL, "true");
+
+        configuration.configure(container);
+
+        String config = configuration.getFileHandler().readTextFile(
+                configuration.getHome() + "/conf/server.xml", StandardCharsets.UTF_8);
+        XMLAssert.assertXpathEvaluatesTo("org.apache.coyote.http11.Http11Nio2Protocol",
+                "//Server/Service/Connector[@port='8080']/@protocol", config);
         XMLAssert.assertXpathExists(
                 "//Server/Service/Connector[@port='8080']"
                         + "/UpgradeProtocol[@className='org.apache.coyote.http2.Http2Protocol']",


### PR DESCRIPTION
 * The old implementation assumed that only a handful of different protocol classes would be used. It didn't support Nio2 or Apr protocol classes, and would break if some other custom protocol class was used too
 * This implementation uses a different connector xpath expression based on the value of the custom connector protocol class property. If it's not set, then the old selector is still used.
 * Verified that interactions with the customized connector protocol still work, so that things like HTTP/2 upgrade are guaranteed to be configured correctly when Nio2 or Apr classes are used