### PR TITLE
Added parameter 'cargo.maven.useLogCategoryPrefix' to maven plugin

### DIFF
--- a/extensions/maven3/plugin/src/main/java/org/codehaus/cargo/maven3/AbstractCargoMojo.java
+++ b/extensions/maven3/plugin/src/main/java/org/codehaus/cargo/maven3/AbstractCargoMojo.java
@@ -177,6 +177,12 @@ public abstract class AbstractCargoMojo extends AbstractCommonMojo
     private boolean skip;
 
     /**
+     * Set this to <code>false</code> to bypass [category] log prefix.
+     */
+    @Parameter(property = "cargo.maven.useLogCategoryPrefix", defaultValue = "true")
+    private boolean useLogCategoryPrefix;
+
+    /**
      * @see org.codehaus.cargo.maven3.util.CargoProject
      */
     private CargoProject cargoProject;
@@ -971,7 +977,7 @@ public abstract class AbstractCargoMojo extends AbstractCommonMojo
         }
         else
         {
-            logger = new MavenLogger(getLog());
+            logger = new MavenLogger(getLog(), useLogCategoryPrefix);
         }
 
         if (getContainerElement() != null && getContainerElement().getLogLevel() != null)

--- a/extensions/maven3/plugin/src/main/java/org/codehaus/cargo/maven3/log/MavenLogger.java
+++ b/extensions/maven3/plugin/src/main/java/org/codehaus/cargo/maven3/log/MavenLogger.java
@@ -34,11 +34,18 @@ public class MavenLogger extends AbstractLogger
     private Log logger;
 
     /**
-     * @param logger the Maven 3 logger to send messages to
+     * If <code>false</code> the formatted category prefix will be omitted
      */
-    public MavenLogger(Log logger)
+    private boolean useLogCategoryPrefix;
+
+    /**
+     * @param logger the Maven 3 logger to send messages to
+     * @param useLogCategoryPrefix If <code>false</code> the formatted category prefix
+     */
+    public MavenLogger(Log logger, boolean useLogCategoryPrefix)
     {
         this.logger = logger;
+        this.useLogCategoryPrefix = useLogCategoryPrefix;
     }
 
     /**
@@ -72,6 +79,11 @@ public class MavenLogger extends AbstractLogger
      */
     private String formatMessage(String message, String category)
     {
+        if (!this.useLogCategoryPrefix)
+        {
+            return message;
+        }
+
         String formattedCategory = category.length() > 20
             ? category.substring(category.length() - 20) : category;
 


### PR DESCRIPTION
Added parameter to maven plugin to allow the user to disable category  log prefix, because sometimes this prefix consume too much space in console and/or make messages less readable.