### PR TITLE
Property to tell to Tomcat to map JARs in WEB-INF/lib or WEB-INF/classes

### DIFF
--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat8xStandaloneLocalConfiguration.java
@@ -203,10 +203,16 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
      */
     private void writeJarPostResource(StringBuilder sb, String path)
     {
+      if (Boolean.parseBoolean(getPropertyValue(TomcatPropertySet.CONTEXT_MAPJARSTOWEBINFCLASSES))) {
+        sb.append("className=\"" + JAR_RESOURCE_SET + "\" base=\"");
+        sb.append(path.replace("&", "&amp;"));
+        sb.append("\" webAppMount=\"/WEB-INF/classes/");
+      } else {
         sb.append("className=\"" + FILE_RESOURCE_SET + "\" base=\"");
         sb.append(path.replace("&", "&amp;"));
         sb.append("\" webAppMount=\"/WEB-INF/lib/");
         sb.append(getFileHandler().getName(path).replace("&", "&amp;"));
+      }
     }
 
     /**
@@ -217,10 +223,16 @@ public class Tomcat8xStandaloneLocalConfiguration extends Tomcat7xStandaloneLoca
      */
     private void writeJarPostResource(Element postResourceEl, String path)
     {
+      if (Boolean.parseBoolean(getPropertyValue(TomcatPropertySet.CONTEXT_MAPJARSTOWEBINFCLASSES))) {
+        postResourceEl.setAttribute("className", JAR_RESOURCE_SET);
+        postResourceEl.setAttribute("base", path.replace("&", "&amp;"));
+        postResourceEl.setAttribute("webAppMount", "/WEB-INF/classes/");
+      } else {
         postResourceEl.setAttribute("className", FILE_RESOURCE_SET);
         postResourceEl.setAttribute("base", path.replace("&", "&amp;"));
         postResourceEl.setAttribute("webAppMount", "/WEB-INF/lib/"
             + getFileHandler().getName(path).replace("&", "&amp;"));
+      }
     }
 
     /**

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/TomcatPropertySet.java
@@ -55,6 +55,11 @@ public interface TomcatPropertySet
     String CONTEXT_ALLOWWEBJARS = "cargo.tomcat.context.addWebinfClassesResources";
 
     /**
+     * Whether the contexts for deployed webapplications should map JARs to WEB-INF/classes
+     */
+    String CONTEXT_MAPJARSTOWEBINFCLASSES = "cargo.tomcat.context.mapJarToWebinfClasses";
+
+    /**
      * Whether WAR deployables should be copied or referenced.
      */
     String COPY_WARS = "cargo.tomcat.copywars";


### PR DESCRIPTION
Use case : Chapter Ordering in https://tomcat.apache.org/tomcat-8.0-doc/config/resources.html

`Since both resources are PostResources, it might be expected that D:\Projects\external\classes will be searched for classes before D:\Projects\lib\library1.jar. However, by adding the JAR using a FileResourceSet, the JAR is mapped to /WEB-INF/lib and will be processed at application start along with the other JARs in /WEB-INF/lib. The classes from the JAR file will be added to the ClassResources which means they will be searched before the classes from D:\Projects\external\classes. If the desired behaviour is that D:\Projects\external\classes is searched before D:\Projects\lib\library1.jar then a slightly different configuration is required:

<Resources>
  <PostResources base="D:\Projects\external\classes"
                 className="org.apache.catalina.webresources.DirResourceSet"
                 webAppMount="/WEB-INF/classes"/>
  <PostResources base="D:\Projects\lib\library1.jar"
                 className="org.apache.catalina.webresources.JarResourceSet"
                 webAppMount="/WEB-INF/classes"/>
</Resources>
In short, the JAR file should be added as a JarResourceSet mapped to /WEB-INF/classes rather than using a FileResourceSet mapped to /WEB-INF/lib.`