### PR TITLE
Potential fix for code scanning alert no. 108: User-controlled data in numeric cast

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/http/HttpRequest.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/http/HttpRequest.java
@@ -227,8 +227,14 @@ public class HttpRequest extends LoggedObject
             connection.setUseCaches(false);
             if (timeout != 0)
             {
-                connection.setReadTimeout((int) timeout);
-                connection.setConnectTimeout((int) timeout);
+                if (timeout < 0 || timeout > Integer.MAX_VALUE)
+                {
+                    throw new IllegalArgumentException("Invalid timeout value [" + timeout
+                        + "], must be between 0 and " + Integer.MAX_VALUE + " milliseconds");
+                }
+                int connectionTimeout = (int) timeout;
+                connection.setReadTimeout(connectionTimeout);
+                connection.setConnectTimeout(connectionTimeout);
             }
             // Do not forcibly close the connection, rather have it kept alive for efficient HTTP
             // resource pooling in case of multiple requests to the same server

--- a/core/api/container/src/main/java/org/codehaus/cargo/container/internal/http/HttpRequest.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/internal/http/HttpRequest.java
@@ -64,6 +64,11 @@ public class HttpRequest extends LoggedObject
     protected static final int BUFFER_CHUNK_SIZE = 256 * 1024;
 
     /**
+     * Maximum timeout (milliseconds).
+     */
+    protected static final int MAX_TIMEOUT = 60 * 60 * 1000;
+
+    /**
      * cache of nonce values seen
      */
     private static final NonceCounter NONCE_COUNTER = new NonceCounter();
@@ -227,10 +232,10 @@ public class HttpRequest extends LoggedObject
             connection.setUseCaches(false);
             if (timeout != 0)
             {
-                if (timeout < 0 || timeout > Integer.MAX_VALUE)
+                if (timeout < 0 || timeout > HttpRequest.MAX_TIMEOUT)
                 {
                     throw new IllegalArgumentException("Invalid timeout value [" + timeout
-                        + "], must be between 0 and " + Integer.MAX_VALUE + " milliseconds");
+                        + "], must be between 0 and " + HttpRequest.MAX_TIMEOUT + " milliseconds");
                 }
                 int connectionTimeout = (int) timeout;
                 connection.setReadTimeout(connectionTimeout);

--- a/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat4xRuntimeConfiguration.java
+++ b/core/containers/tomcat/src/main/java/org/codehaus/cargo/container/tomcat/Tomcat4xRuntimeConfiguration.java
@@ -33,7 +33,7 @@ public class Tomcat4xRuntimeConfiguration extends AbstractRuntimeConfiguration
     /**
      * Default timeout for Tomcat (in milliseconds).
      */
-    private static final long TWO_HOURS = 2 * 60 * 60 * 1000;
+    private static final long TEN_MINUTES = 10 * 60 * 1000;
 
     /**
      * Capability of the Tomcat runtime configuration.
@@ -48,7 +48,7 @@ public class Tomcat4xRuntimeConfiguration extends AbstractRuntimeConfiguration
     public Tomcat4xRuntimeConfiguration()
     {
         setProperty(TomcatPropertySet.DEPLOY_UPDATE, "false");
-        setProperty(RemotePropertySet.TIMEOUT, Long.toString(TWO_HOURS));
+        setProperty(RemotePropertySet.TIMEOUT, Long.toString(TEN_MINUTES));
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/codehaus-cargo/cargo/security/code-scanning/108](https://github.com/codehaus-cargo/cargo/security/code-scanning/108)

Use explicit range validation before narrowing `long timeout` to `int` in `HttpRequest.connect`, and fail fast if the value is outside `int` bounds (or negative). This preserves behavior for valid values and prevents truncation.

Best fix in this codebase:
- Edit `core/api/container/src/main/java/org/codehaus/cargo/container/internal/http/HttpRequest.java`
- In `connect(...)`, replace direct casts `(int) timeout` with guarded conversion:
  - reject negative timeout
  - reject values greater than `Integer.MAX_VALUE`
  - cast only after validation
- Throw `IllegalArgumentException` with a clear message if invalid.

No new dependencies are needed; no import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
