### PR TITLE
Potential fix for code scanning alert no. 78: Uncontrolled data used in path expression

### DIFF
--- a/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
+++ b/core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java
@@ -585,6 +585,13 @@ public class ZipURLInstaller extends LoggedObject implements Installer
             name = this.remoteLocation.getPath().substring(slashPos + 1);
         }
 
+        if (name == null || name.isEmpty() || ".".equals(name) || "..".equals(name)
+            || name.contains("/") || name.contains("\\") || name.contains(".."))
+        {
+            throw new ContainerException("Invalid source file name extracted from URL ["
+                + this.remoteLocation + "]");
+        }
+
         return name;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/codehaus-cargo/cargo/security/code-scanning/78](https://github.com/codehaus-cargo/cargo/security/code-scanning/78)

General fix: validate and constrain any user-influenced path component before using it in file path construction. Here, `getSourceFileName()` must return a safe single filename (no separators, no `..`, not empty), and reject unsafe values.

Best targeted fix (no behavior change beyond rejecting unsafe input):
- **File:** `core/api/container/src/main/java/org/codehaus/cargo/container/installer/ZipURLInstaller.java`
- Update `getSourceFileName()` to:
  - extract the last path segment as today,
  - normalize/validate it as a single filename,
  - reject empty, `"."`, `".."`, names containing `/` or `\`, and names containing `..`.
- Throw `ContainerException` for invalid names so the caller fails safely.
- No new dependency required; use existing classes/imports only.

This keeps normal downloads working while preventing path-manipulation payloads from being used as local target filenames.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
