### PR TITLE
Potential fix for code scanning alert no. 95: Uncontrolled data used in path expression

### DIFF
--- a/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/file/FileManager.java
+++ b/extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/file/FileManager.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.codehaus.cargo.daemon.HandleDatabase;
@@ -321,7 +323,7 @@ public class FileManager
      */
     public String saveFile(String relativeFile, InputStream inputStream) throws IOException
     {
-        String file = fileHandler.append(getWorkspaceDirectory(), relativeFile);
+        String file = resolveSafePath(getWorkspaceDirectory(), relativeFile);
 
         try (OutputStream outputStream = fileHandler.getOutputStream(file))
         {
@@ -347,7 +349,7 @@ public class FileManager
     public String saveFile(String handleId, String relativeFile, InputStream inputStream)
         throws IOException
     {
-        String file = fileHandler.append(getWorkspaceDirectory(handleId), relativeFile);
+        String file = resolveSafePath(getWorkspaceDirectory(handleId), relativeFile);
 
         try (OutputStream outputStream = fileHandler.getOutputStream(file))
         {
@@ -359,6 +361,37 @@ public class FileManager
         }
 
         return file;
+    }
+
+    /**
+     * Resolves a user-provided relative path against a workspace directory and ensures that the
+     * resolved path stays within that workspace.
+     *
+     * @param workspaceDirectory The workspace directory.
+     * @param relativeFile The user-provided relative file path.
+     * @return The normalized safe file path.
+     */
+    private String resolveSafePath(String workspaceDirectory, String relativeFile)
+    {
+        if (relativeFile == null || relativeFile.trim().isEmpty())
+        {
+            throw new IllegalArgumentException("Invalid filename");
+        }
+
+        Path workspacePath = Paths.get(workspaceDirectory).toAbsolutePath().normalize();
+        Path relativePath = Paths.get(relativeFile);
+        if (relativePath.isAbsolute())
+        {
+            throw new IllegalArgumentException("Invalid filename");
+        }
+
+        Path resolvedPath = workspacePath.resolve(relativePath).normalize();
+        if (!resolvedPath.startsWith(workspacePath))
+        {
+            throw new IllegalArgumentException("Invalid filename");
+        }
+
+        return resolvedPath.toString();
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/codehaus-cargo/cargo/security/code-scanning/95](https://github.com/codehaus-cargo/cargo/security/code-scanning/95)

The safest minimal fix is to validate and normalize `relativeFile` in `FileManager.saveFile(...)` before appending it to the workspace path, then enforce that the resolved target remains inside the workspace directory.

Best concrete approach (without changing intended functionality):
- In `extensions/daemon/webapp/src/main/java/org/codehaus/cargo/daemon/file/FileManager.java`:
  - Add a private helper method that:
    - rejects null/empty names,
    - rejects absolute paths,
    - resolves `workspaceDir.resolve(relativeFile).normalize()`,
    - verifies the normalized path starts with normalized workspace dir,
    - returns the safe normalized path as string.
  - Use this helper in both `saveFile(String relativeFile, InputStream inputStream)` and `saveFile(String handleId, String relativeFile, InputStream inputStream)` so both write paths are protected.
- Add `java.nio.file.Path` and `java.nio.file.Paths` imports.
- Throw `IllegalArgumentException` on invalid path input (keeps behavior explicit and avoids silent rewriting).

This preserves existing behavior for valid relative inputs while blocking traversal and absolute-path abuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
